### PR TITLE
Backend prep: cloud headless

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "app_test_support"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -819,7 +819,7 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codex-ansi-escape"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "ansi-to-tui",
  "ratatui",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "codex-protocol",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-client"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1007,12 +1007,12 @@ dependencies = [
  "diffy",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "tokio",
 ]
 
 [[package]]
 name = "codex-common"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "clap",
  "codex-app-server-protocol",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "allocative",
  "anyhow",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-apply"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "once_cell",
  "regex",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-tooling"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "assert_matches",
  "pretty_assertions",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "clap",
  "codex-core",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-client"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "mcp-types",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ollama"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "assert_matches",
  "async-stream",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -1293,14 +1293,14 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol-ts"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "codex-responses-api-proxy"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-string"
-version = "0.0.0"
+version = "0.45.0"
 
 [[package]]
 name = "color-eyre"
@@ -1569,7 +1569,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_test_support"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3451,7 +3451,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-types"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "mcp_test_support"
-version = "0.0.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/codex-rs/cloud-tasks-client/Cargo.toml
+++ b/codex-rs/cloud-tasks-client/Cargo.toml
@@ -22,6 +22,8 @@ chrono = { version = "0.4", features = ["serde"] }
 diffy = "0.4.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "2.0.12"
 codex-backend-client = { path = "../backend-client", optional = true }
 codex-git-apply = { path = "../git-apply" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/codex-rs/cloud-tasks-client/src/lib.rs
+++ b/codex-rs/cloud-tasks-client/src/lib.rs
@@ -13,6 +13,7 @@ pub use api::TaskStatus;
 pub use api::TaskSummary;
 pub use api::TaskText;
 pub use api::TurnAttempt;
+pub use api::TurnHistoryEntry;
 
 #[cfg(feature = "mock")]
 mod mock;


### PR DESCRIPTION
## Summary

- expose request ids in cloud task errors so CLI can surface them consistently
- add mock turn history data for upcoming headless commands
- include unit tests covering error parsing and mock behaviour
