### PR TITLE
strict-v1 p1: packet/config scaffolding and compiler provenance types

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -672,6 +672,14 @@
       },
       "type": "object"
     },
+    "GovernancePathVariant": {
+      "enum": [
+        "off",
+        "strict_v1_shadow",
+        "strict_v1_enforce"
+      ],
+      "type": "string"
+    },
     "GranularApprovalConfig": {
       "properties": {
         "mcp_elicitations": {
@@ -2281,6 +2289,14 @@
       ],
       "default": null,
       "description": "Settings for ghost snapshots (used for undo)."
+    },
+    "governance_path_variant": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/GovernancePathVariant"
+        }
+      ],
+      "description": "Optional strict-governance variant used by typed packet scaffolding."
     },
     "hide_agent_reasoning": {
       "description": "When set to `true`, `AgentReasoning` events will be hidden from the UI/output. Defaults to `false`.",

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -3324,6 +3324,28 @@ fn loads_continuation_bridge_variant_model_and_reasoning() -> std::io::Result<()
 }
 
 #[test]
+fn loads_governance_path_variant() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    let cfg = ConfigToml {
+        governance_path_variant: Some(GovernancePathVariant::StrictV1Shadow),
+        ..Default::default()
+    };
+
+    let config = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        codex_home.path().to_path_buf(),
+    )?;
+
+    assert_eq!(
+        config.governance_path_variant,
+        Some(GovernancePathVariant::StrictV1Shadow)
+    );
+
+    Ok(())
+}
+
+#[test]
 fn load_config_rejects_missing_agent_role_config_file() -> std::io::Result<()> {
     let codex_home = TempDir::new()?;
     let missing_path = codex_home.path().join("agents").join("researcher.toml");
@@ -4595,6 +4617,7 @@ fn test_precedence_fixture_with_o3_profile() -> std::io::Result<()> {
             continuation_bridge_variant: None,
             continuation_bridge_model: None,
             continuation_bridge_reasoning_effort: None,
+            governance_path_variant: None,
             commit_attribution: None,
             forced_chatgpt_workspace_id: None,
             forced_login_method: None,
@@ -4741,6 +4764,7 @@ fn test_precedence_fixture_with_gpt3_profile() -> std::io::Result<()> {
         continuation_bridge_variant: None,
         continuation_bridge_model: None,
         continuation_bridge_reasoning_effort: None,
+        governance_path_variant: None,
         commit_attribution: None,
         forced_chatgpt_workspace_id: None,
         forced_login_method: None,
@@ -4885,6 +4909,7 @@ fn test_precedence_fixture_with_zdr_profile() -> std::io::Result<()> {
         continuation_bridge_variant: None,
         continuation_bridge_model: None,
         continuation_bridge_reasoning_effort: None,
+        governance_path_variant: None,
         commit_attribution: None,
         forced_chatgpt_workspace_id: None,
         forced_login_method: None,
@@ -5015,6 +5040,7 @@ fn test_precedence_fixture_with_gpt5_profile() -> std::io::Result<()> {
         continuation_bridge_variant: None,
         continuation_bridge_model: None,
         continuation_bridge_reasoning_effort: None,
+        governance_path_variant: None,
         commit_attribution: None,
         forced_chatgpt_workspace_id: None,
         forced_login_method: None,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -129,6 +129,15 @@ pub enum ContinuationBridgeVariant {
     Baton,
     RichReview,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernancePathVariant {
+    #[default]
+    Off,
+    StrictV1Shadow,
+    StrictV1Enforce,
+}
 pub use permissions::FilesystemPermissionToml;
 pub use permissions::FilesystemPermissionsToml;
 pub use permissions::NetworkDomainPermissionToml;
@@ -302,6 +311,9 @@ pub struct Config {
 
     /// Optional reasoning effort override used only for continuation-bridge generation.
     pub continuation_bridge_reasoning_effort: Option<ReasoningEffort>,
+
+    /// Optional strict-governance variant used by typed packet scaffolding.
+    pub governance_path_variant: Option<GovernancePathVariant>,
 
     /// Optional commit attribution text for commit message co-author trailers.
     ///
@@ -1177,6 +1189,9 @@ pub struct ConfigToml {
 
     /// Optional reasoning effort override used only for continuation-bridge generation.
     pub continuation_bridge_reasoning_effort: Option<ReasoningEffort>,
+
+    /// Optional strict-governance variant used by typed packet scaffolding.
+    pub governance_path_variant: Option<GovernancePathVariant>,
 
     /// Optional commit attribution text for commit message co-author trailers.
     ///
@@ -2450,6 +2465,7 @@ impl Config {
         });
         let continuation_bridge_variant = cfg.continuation_bridge_variant;
         let continuation_bridge_reasoning_effort = cfg.continuation_bridge_reasoning_effort;
+        let governance_path_variant = cfg.governance_path_variant;
 
         let commit_attribution = cfg.commit_attribution;
 
@@ -2639,6 +2655,7 @@ impl Config {
             continuation_bridge_variant,
             continuation_bridge_model,
             continuation_bridge_reasoning_effort,
+            governance_path_variant,
             commit_attribution,
             // The config.toml omits "_mode" because it's a config file. However, "_mode"
             // is important in code to differentiate the mode from the store implementation.

--- a/codex-rs/core/src/continuation_bridge.rs
+++ b/codex-rs/core/src/continuation_bridge.rs
@@ -150,7 +150,7 @@ fn parse_continuation_bridge_response(
         Some(Ok(value)) => value,
         Some(Err(err)) => {
             let response_chars = result.chars().count();
-            let preview = preview_text(result, 1_024);
+            let preview = preview_text(result, /*max_chars*/ 1_024);
             warn!(
                 "failed parsing continuation bridge response: {err}; response_chars={response_chars}; response_preview={preview:?}"
             );
@@ -166,7 +166,7 @@ fn parse_continuation_bridge_response(
     let trailing = result[stream.byte_offset()..].trim();
     if !trailing.is_empty() {
         let trailing_chars = trailing.chars().count();
-        let trailing_preview = preview_text(trailing, 512);
+        let trailing_preview = preview_text(trailing, /*max_chars*/ 512);
         warn!(
             "ignoring trailing content after continuation bridge JSON: trailing_chars={trailing_chars}; trailing_preview={trailing_preview:?}"
         );

--- a/codex-rs/core/src/governance/compiler.rs
+++ b/codex-rs/core/src/governance/compiler.rs
@@ -92,10 +92,13 @@ pub enum GovernanceCompileError {
         source_id: String,
         reason: String,
     },
-    #[error("duplicate packet for layer `{layer:?}` from source `{source_id}`")]
+    #[error(
+        "duplicate packet for layer `{layer:?}` from source `{source_id}` (already provided by `{existing_source_id}`)"
+    )]
     DuplicateLayerPacket {
         layer: PacketLayer,
         source_id: String,
+        existing_source_id: String,
     },
     #[error("governance path `{path_variant:?}` requires a constitution packet")]
     MissingConstitutionPacket { path_variant: GovernancePathVariant },
@@ -113,97 +116,82 @@ pub fn compile_packets(
                 source_kind,
                 packet,
             } => {
-                let identity = packet.identity();
-                if identity.packet_id.trim().is_empty() {
+                let (packet_id, content_hash, schema) = {
+                    let identity = packet.identity();
+                    (
+                        identity.packet_id.clone(),
+                        identity.content_hash.clone(),
+                        identity.schema.clone(),
+                    )
+                };
+                if packet_id.trim().is_empty() {
                     return Err(GovernanceCompileError::InvalidPacketIdentity {
-                        packet_id: identity.packet_id.clone(),
+                        packet_id: packet_id.clone(),
                         source_id,
                         reason: "packet_id must be non-empty".to_string(),
                     });
                 }
-                if identity.content_hash.trim().is_empty() {
+                if content_hash.trim().is_empty() {
                     return Err(GovernanceCompileError::InvalidPacketIdentity {
-                        packet_id: identity.packet_id.clone(),
+                        packet_id: packet_id.clone(),
                         source_id,
                         reason: "content_hash must be non-empty".to_string(),
                     });
                 }
-                if identity.schema.trim().is_empty() {
+                if schema.trim().is_empty() {
                     return Err(GovernanceCompileError::InvalidPacketIdentity {
-                        packet_id: identity.packet_id.clone(),
+                        packet_id: packet_id.clone(),
                         source_id,
                         reason: "schema must be non-empty".to_string(),
                     });
                 }
 
                 let layer = packet.layer();
+                if let Some(existing_source_id) = compiled
+                    .projection_witness
+                    .accepted
+                    .iter()
+                    .find(|projection| projection.layer == layer)
+                    .map(|projection| projection.source_id.clone())
+                {
+                    return Err(GovernanceCompileError::DuplicateLayerPacket {
+                        layer,
+                        source_id,
+                        existing_source_id,
+                    });
+                }
+
+                match packet {
+                    GovernancePacket::Constitution(packet) => {
+                        compiled.constitution = Some(packet);
+                    }
+                    GovernancePacket::Role(packet) => {
+                        compiled.role = Some(packet);
+                    }
+                    GovernancePacket::TaskCharter(packet) => {
+                        compiled.task_charter = Some(packet);
+                    }
+                    GovernancePacket::TaskResidual(packet) => {
+                        compiled.task_residual = Some(packet);
+                    }
+                    GovernancePacket::RuntimeFactStore(packet) => {
+                        compiled.runtime_fact_store = Some(packet);
+                    }
+                    GovernancePacket::AdapterOverlay(packet) => {
+                        compiled.adapter_overlay = Some(packet);
+                    }
+                }
+
                 compiled
                     .projection_witness
                     .accepted
                     .push(AcceptedPacketProjection {
-                        source_id: source_id.clone(),
+                        source_id,
                         source_kind,
                         layer,
-                        packet_id: identity.packet_id.clone(),
-                        content_hash: identity.content_hash.clone(),
+                        packet_id,
+                        content_hash,
                     });
-
-                match packet {
-                    GovernancePacket::Constitution(packet) => {
-                        if compiled.constitution.is_some() {
-                            return Err(GovernanceCompileError::DuplicateLayerPacket {
-                                layer,
-                                source_id,
-                            });
-                        }
-                        compiled.constitution = Some(packet);
-                    }
-                    GovernancePacket::Role(packet) => {
-                        if compiled.role.is_some() {
-                            return Err(GovernanceCompileError::DuplicateLayerPacket {
-                                layer,
-                                source_id,
-                            });
-                        }
-                        compiled.role = Some(packet);
-                    }
-                    GovernancePacket::TaskCharter(packet) => {
-                        if compiled.task_charter.is_some() {
-                            return Err(GovernanceCompileError::DuplicateLayerPacket {
-                                layer,
-                                source_id,
-                            });
-                        }
-                        compiled.task_charter = Some(packet);
-                    }
-                    GovernancePacket::TaskResidual(packet) => {
-                        if compiled.task_residual.is_some() {
-                            return Err(GovernanceCompileError::DuplicateLayerPacket {
-                                layer,
-                                source_id,
-                            });
-                        }
-                        compiled.task_residual = Some(packet);
-                    }
-                    GovernancePacket::RuntimeFactStore(packet) => {
-                        if compiled.runtime_fact_store.is_some() {
-                            return Err(GovernanceCompileError::DuplicateLayerPacket {
-                                layer,
-                                source_id,
-                            });
-                        }
-                        compiled.runtime_fact_store = Some(packet);
-                    }
-                    GovernancePacket::AdapterOverlay(packet) => {
-                        if compiled.adapter_overlay.is_some() {
-                            return Err(GovernanceCompileError::DuplicateLayerPacket {
-                                layer,
-                                source_id,
-                            });
-                        }
-                        compiled.adapter_overlay = Some(packet);
-                    }
-                }
             }
             SourceFragment::MixedLayer {
                 source_id,
@@ -347,7 +335,8 @@ mod tests {
             err,
             GovernanceCompileError::DuplicateLayerPacket {
                 layer: PacketLayer::Constitution,
-                source_id: "config:b".to_string()
+                source_id: "config:b".to_string(),
+                existing_source_id: "config:a".to_string(),
             }
         );
     }

--- a/codex-rs/core/src/governance/compiler.rs
+++ b/codex-rs/core/src/governance/compiler.rs
@@ -1,0 +1,386 @@
+use crate::config::GovernancePathVariant;
+use crate::governance::packets::AdapterOverlayPacket;
+use crate::governance::packets::ConstitutionPacket;
+use crate::governance::packets::GovernancePacket;
+use crate::governance::packets::PacketLayer;
+use crate::governance::packets::RolePacket;
+use crate::governance::packets::RuntimeFactStore;
+use crate::governance::packets::TaskCharterPacket;
+use crate::governance::packets::TaskResidualPacket;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PacketSourceKind {
+    InlineConfig,
+    FileArtifact,
+    PromptChannel,
+    RuntimeState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "classification", rename_all = "snake_case")]
+pub enum SourceFragment {
+    Packet {
+        source_id: String,
+        source_kind: PacketSourceKind,
+        packet: GovernancePacket,
+    },
+    MixedLayer {
+        source_id: String,
+        source_kind: PacketSourceKind,
+        claimed_layers: Vec<PacketLayer>,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct GovernanceCompilationInput {
+    pub path_variant: GovernancePathVariant,
+    pub fragments: Vec<SourceFragment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct AcceptedPacketProjection {
+    pub source_id: String,
+    pub source_kind: PacketSourceKind,
+    pub layer: PacketLayer,
+    pub packet_id: String,
+    pub content_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RejectedFragmentProjection {
+    pub source_id: String,
+    pub source_kind: PacketSourceKind,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ProjectionAmbiguity {
+    pub source_id: String,
+    pub source_kind: PacketSourceKind,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+pub struct ProjectionWitness {
+    pub accepted: Vec<AcceptedPacketProjection>,
+    pub rejected: Vec<RejectedFragmentProjection>,
+    pub ambiguities: Vec<ProjectionAmbiguity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+pub struct CompiledGovernancePackets {
+    pub constitution: Option<ConstitutionPacket>,
+    pub role: Option<RolePacket>,
+    pub task_charter: Option<TaskCharterPacket>,
+    pub task_residual: Option<TaskResidualPacket>,
+    pub runtime_fact_store: Option<RuntimeFactStore>,
+    pub adapter_overlay: Option<AdapterOverlayPacket>,
+    pub projection_witness: ProjectionWitness,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum GovernanceCompileError {
+    #[error("packet `{packet_id}` from source `{source_id}` has invalid identity: {reason}")]
+    InvalidPacketIdentity {
+        packet_id: String,
+        source_id: String,
+        reason: String,
+    },
+    #[error("duplicate packet for layer `{layer:?}` from source `{source_id}`")]
+    DuplicateLayerPacket {
+        layer: PacketLayer,
+        source_id: String,
+    },
+    #[error("governance path `{path_variant:?}` requires a constitution packet")]
+    MissingConstitutionPacket { path_variant: GovernancePathVariant },
+}
+
+pub fn compile_packets(
+    input: GovernanceCompilationInput,
+) -> Result<CompiledGovernancePackets, GovernanceCompileError> {
+    let mut compiled = CompiledGovernancePackets::default();
+
+    for fragment in input.fragments {
+        match fragment {
+            SourceFragment::Packet {
+                source_id,
+                source_kind,
+                packet,
+            } => {
+                let identity = packet.identity();
+                if identity.packet_id.trim().is_empty() {
+                    return Err(GovernanceCompileError::InvalidPacketIdentity {
+                        packet_id: identity.packet_id.clone(),
+                        source_id,
+                        reason: "packet_id must be non-empty".to_string(),
+                    });
+                }
+                if identity.content_hash.trim().is_empty() {
+                    return Err(GovernanceCompileError::InvalidPacketIdentity {
+                        packet_id: identity.packet_id.clone(),
+                        source_id,
+                        reason: "content_hash must be non-empty".to_string(),
+                    });
+                }
+                if identity.schema.trim().is_empty() {
+                    return Err(GovernanceCompileError::InvalidPacketIdentity {
+                        packet_id: identity.packet_id.clone(),
+                        source_id,
+                        reason: "schema must be non-empty".to_string(),
+                    });
+                }
+
+                let layer = packet.layer();
+                compiled
+                    .projection_witness
+                    .accepted
+                    .push(AcceptedPacketProjection {
+                        source_id: source_id.clone(),
+                        source_kind,
+                        layer,
+                        packet_id: identity.packet_id.clone(),
+                        content_hash: identity.content_hash.clone(),
+                    });
+
+                match packet {
+                    GovernancePacket::Constitution(packet) => {
+                        if compiled.constitution.is_some() {
+                            return Err(GovernanceCompileError::DuplicateLayerPacket {
+                                layer,
+                                source_id,
+                            });
+                        }
+                        compiled.constitution = Some(packet);
+                    }
+                    GovernancePacket::Role(packet) => {
+                        if compiled.role.is_some() {
+                            return Err(GovernanceCompileError::DuplicateLayerPacket {
+                                layer,
+                                source_id,
+                            });
+                        }
+                        compiled.role = Some(packet);
+                    }
+                    GovernancePacket::TaskCharter(packet) => {
+                        if compiled.task_charter.is_some() {
+                            return Err(GovernanceCompileError::DuplicateLayerPacket {
+                                layer,
+                                source_id,
+                            });
+                        }
+                        compiled.task_charter = Some(packet);
+                    }
+                    GovernancePacket::TaskResidual(packet) => {
+                        if compiled.task_residual.is_some() {
+                            return Err(GovernanceCompileError::DuplicateLayerPacket {
+                                layer,
+                                source_id,
+                            });
+                        }
+                        compiled.task_residual = Some(packet);
+                    }
+                    GovernancePacket::RuntimeFactStore(packet) => {
+                        if compiled.runtime_fact_store.is_some() {
+                            return Err(GovernanceCompileError::DuplicateLayerPacket {
+                                layer,
+                                source_id,
+                            });
+                        }
+                        compiled.runtime_fact_store = Some(packet);
+                    }
+                    GovernancePacket::AdapterOverlay(packet) => {
+                        if compiled.adapter_overlay.is_some() {
+                            return Err(GovernanceCompileError::DuplicateLayerPacket {
+                                layer,
+                                source_id,
+                            });
+                        }
+                        compiled.adapter_overlay = Some(packet);
+                    }
+                }
+            }
+            SourceFragment::MixedLayer {
+                source_id,
+                source_kind,
+                claimed_layers,
+                reason,
+            } => {
+                let claimed = claimed_layers
+                    .iter()
+                    .map(|layer| format!("{layer:?}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                compiled
+                    .projection_witness
+                    .rejected
+                    .push(RejectedFragmentProjection {
+                        source_id,
+                        source_kind,
+                        reason: format!("{reason}; claimed_layers=[{claimed}]"),
+                    });
+            }
+        }
+    }
+
+    if input.path_variant != GovernancePathVariant::Off && compiled.constitution.is_none() {
+        return Err(GovernanceCompileError::MissingConstitutionPacket {
+            path_variant: input.path_variant,
+        });
+    }
+
+    Ok(compiled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GovernanceCompilationInput;
+    use super::GovernanceCompileError;
+    use super::PacketSourceKind;
+    use super::SourceFragment;
+    use super::compile_packets;
+    use crate::config::GovernancePathVariant;
+    use crate::governance::packets::ConstitutionPacket;
+    use crate::governance::packets::GovernanceClause;
+    use crate::governance::packets::GovernancePacket;
+    use crate::governance::packets::NormativeForce;
+    use crate::governance::packets::PacketIdentity;
+    use crate::governance::packets::PacketLayer;
+    use pretty_assertions::assert_eq;
+
+    fn constitution_packet(packet_id: &str) -> ConstitutionPacket {
+        ConstitutionPacket {
+            identity: PacketIdentity {
+                packet_id: packet_id.to_string(),
+                content_hash: "sha256:abc123".to_string(),
+                schema: "constitution_packet@1".to_string(),
+            },
+            clauses: vec![GovernanceClause {
+                force: NormativeForce::Hard,
+                subject: "tool_safety".to_string(),
+                instruction: "never bypass approval requirements".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn off_variant_allows_empty_packet_set() {
+        let compiled = compile_packets(GovernanceCompilationInput {
+            path_variant: GovernancePathVariant::Off,
+            fragments: Vec::new(),
+        })
+        .expect("off variant should allow empty compilation input");
+
+        assert_eq!(compiled.constitution, None);
+        assert_eq!(compiled.projection_witness.accepted, Vec::new());
+        assert_eq!(compiled.projection_witness.rejected, Vec::new());
+        assert_eq!(compiled.projection_witness.ambiguities, Vec::new());
+    }
+
+    #[test]
+    fn strict_variant_requires_constitution_packet() {
+        let err = compile_packets(GovernanceCompilationInput {
+            path_variant: GovernancePathVariant::StrictV1Enforce,
+            fragments: Vec::new(),
+        })
+        .expect_err("strict path should require constitution packet");
+
+        assert_eq!(
+            err,
+            GovernanceCompileError::MissingConstitutionPacket {
+                path_variant: GovernancePathVariant::StrictV1Enforce
+            }
+        );
+    }
+
+    #[test]
+    fn compile_accepts_constitution_and_records_provenance() {
+        let packet = constitution_packet("constitution@main");
+        let compiled = compile_packets(GovernanceCompilationInput {
+            path_variant: GovernancePathVariant::StrictV1Shadow,
+            fragments: vec![SourceFragment::Packet {
+                source_id: "config:constitution".to_string(),
+                source_kind: PacketSourceKind::FileArtifact,
+                packet: GovernancePacket::Constitution(packet.clone()),
+            }],
+        })
+        .expect("compilation should succeed");
+
+        assert_eq!(compiled.constitution, Some(packet));
+        assert_eq!(compiled.projection_witness.accepted.len(), 1);
+        assert_eq!(
+            compiled.projection_witness.accepted[0].source_id,
+            "config:constitution"
+        );
+        assert_eq!(
+            compiled.projection_witness.accepted[0].layer,
+            PacketLayer::Constitution
+        );
+        assert_eq!(compiled.projection_witness.rejected, Vec::new());
+    }
+
+    #[test]
+    fn compile_rejects_duplicate_layers() {
+        let err = compile_packets(GovernanceCompilationInput {
+            path_variant: GovernancePathVariant::StrictV1Shadow,
+            fragments: vec![
+                SourceFragment::Packet {
+                    source_id: "config:a".to_string(),
+                    source_kind: PacketSourceKind::InlineConfig,
+                    packet: GovernancePacket::Constitution(constitution_packet("a")),
+                },
+                SourceFragment::Packet {
+                    source_id: "config:b".to_string(),
+                    source_kind: PacketSourceKind::InlineConfig,
+                    packet: GovernancePacket::Constitution(constitution_packet("b")),
+                },
+            ],
+        })
+        .expect_err("duplicate constitution packets should fail");
+
+        assert_eq!(
+            err,
+            GovernanceCompileError::DuplicateLayerPacket {
+                layer: PacketLayer::Constitution,
+                source_id: "config:b".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn compile_records_mixed_layer_rejections() {
+        let compiled = compile_packets(GovernanceCompilationInput {
+            path_variant: GovernancePathVariant::StrictV1Shadow,
+            fragments: vec![
+                SourceFragment::MixedLayer {
+                    source_id: "prompt:bundle".to_string(),
+                    source_kind: PacketSourceKind::PromptChannel,
+                    claimed_layers: vec![PacketLayer::Role, PacketLayer::TaskCharter],
+                    reason: "mixed-layer fragment".to_string(),
+                },
+                SourceFragment::Packet {
+                    source_id: "config:constitution".to_string(),
+                    source_kind: PacketSourceKind::FileArtifact,
+                    packet: GovernancePacket::Constitution(constitution_packet("main")),
+                },
+            ],
+        })
+        .expect("compilation should succeed");
+
+        assert_eq!(compiled.projection_witness.rejected.len(), 1);
+        assert_eq!(
+            compiled.projection_witness.rejected[0].source_id,
+            "prompt:bundle"
+        );
+        assert!(
+            compiled.projection_witness.rejected[0]
+                .reason
+                .contains("claimed_layers=[Role, TaskCharter]")
+        );
+    }
+}

--- a/codex-rs/core/src/governance/mod.rs
+++ b/codex-rs/core/src/governance/mod.rs
@@ -1,0 +1,2 @@
+pub mod compiler;
+pub mod packets;

--- a/codex-rs/core/src/governance/packets.rs
+++ b/codex-rs/core/src/governance/packets.rs
@@ -1,0 +1,120 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum NormativeForce {
+    Hard,
+    Default,
+    Advisory,
+    Factual,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct PacketIdentity {
+    pub packet_id: String,
+    pub content_hash: String,
+    pub schema: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct GovernanceClause {
+    pub force: NormativeForce,
+    pub subject: String,
+    pub instruction: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RuntimeFact {
+    pub key: String,
+    pub value: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ConstitutionPacket {
+    pub identity: PacketIdentity,
+    pub clauses: Vec<GovernanceClause>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RolePacket {
+    pub identity: PacketIdentity,
+    pub role_name: String,
+    pub posture: Vec<GovernanceClause>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct TaskCharterPacket {
+    pub identity: PacketIdentity,
+    pub assignment_id: String,
+    pub ordered_obligations: Vec<GovernanceClause>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct TaskResidualPacket {
+    pub identity: PacketIdentity,
+    pub open_obligations: Vec<GovernanceClause>,
+    pub blockers: Vec<String>,
+    pub accepted_decisions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RuntimeFactStore {
+    pub identity: PacketIdentity,
+    pub facts: Vec<RuntimeFact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct AdapterOverlayPacket {
+    pub identity: PacketIdentity,
+    pub adapter_id: String,
+    pub clauses: Vec<GovernanceClause>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PacketLayer {
+    Constitution,
+    Role,
+    TaskCharter,
+    TaskResidual,
+    RuntimeFactStore,
+    AdapterOverlay,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "packet_type", rename_all = "snake_case")]
+pub enum GovernancePacket {
+    Constitution(ConstitutionPacket),
+    Role(RolePacket),
+    TaskCharter(TaskCharterPacket),
+    TaskResidual(TaskResidualPacket),
+    RuntimeFactStore(RuntimeFactStore),
+    AdapterOverlay(AdapterOverlayPacket),
+}
+
+impl GovernancePacket {
+    pub fn identity(&self) -> &PacketIdentity {
+        match self {
+            Self::Constitution(packet) => &packet.identity,
+            Self::Role(packet) => &packet.identity,
+            Self::TaskCharter(packet) => &packet.identity,
+            Self::TaskResidual(packet) => &packet.identity,
+            Self::RuntimeFactStore(packet) => &packet.identity,
+            Self::AdapterOverlay(packet) => &packet.identity,
+        }
+    }
+
+    pub fn layer(&self) -> PacketLayer {
+        match self {
+            Self::Constitution(_) => PacketLayer::Constitution,
+            Self::Role(_) => PacketLayer::Role,
+            Self::TaskCharter(_) => PacketLayer::TaskCharter,
+            Self::TaskResidual(_) => PacketLayer::TaskResidual,
+            Self::RuntimeFactStore(_) => PacketLayer::RuntimeFactStore,
+            Self::AdapterOverlay(_) => PacketLayer::AdapterOverlay,
+        }
+    }
+}

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod file_watcher;
 mod flags;
 #[cfg(test)]
 mod git_info_tests;
+pub mod governance;
 mod guardian;
 mod hook_runtime;
 pub mod instructions;

--- a/docs/config.md
+++ b/docs/config.md
@@ -55,6 +55,17 @@ The built-in bridge artifacts now live under:
 
 The default runtime variant is `baton`, and bridge generation defaults to `gpt-5-codex-mini` with `high` reasoning unless you override those settings.
 
+## Governance path
+
+This fork now includes strict-governance packet scaffolding behind a config gate:
+
+- `governance_path_variant = "off"` (default)
+- `governance_path_variant = "strict_v1_shadow"`
+- `governance_path_variant = "strict_v1_enforce"`
+
+`strict_v1_shadow` and `strict_v1_enforce` currently only configure packet/compiler scaffolding.
+They do not switch core runtime behavior yet.
+
 ## JSON Schema
 
 The generated JSON Schema for `config.toml` lives at `codex-rs/core/config.schema.json`.


### PR DESCRIPTION
## Summary
- add strict-v1 governance packet scaffolding in codex-core under core/src/governance/
- add typed packet models (ConstitutionPacket, RolePacket, TaskCharterPacket, TaskResidualPacket, RuntimeFactStore, AdapterOverlayPacket) and NormativeForce
- add packet compiler/provenance types and compile entrypoint (compile_packets) with duplicate-layer + identity validation
- add config gate enum governance_path_variant (off, strict_v1_shadow, strict_v1_enforce) and wire it into Config + schema
- add docs for governance path in docs/config.md
- keep this as scaffolding only: no behavioral switch-on in runtime paths

## Validation
- just fmt
- cargo test -p codex-core (fails in pre-existing flaky tests unrelated to this diff)
  - shell_snapshot::tests::timed_out_snapshot_shell_is_terminated
  - unified_exec::tests::completed_pipe_commands_preserve_exit_code
  - unified_exec::tests::unified_exec_pause_blocks_yield_timeout
- python3 tools/argument-comment-lint/run.py -p codex-core
- just fix -p codex-core
