### PR TITLE
strict-v1 p3: add ODEU thread-memory compaction path

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1014,6 +1014,10 @@ impl TurnContext {
         )
     }
 
+    pub(crate) fn governance_path_variant(&self) -> crate::config::GovernancePathVariant {
+        self.config.governance_path_variant.unwrap_or_default()
+    }
+
     pub(crate) fn to_turn_context_item(&self) -> TurnContextItem {
         TurnContextItem {
             turn_id: Some(self.sub_id.clone()),

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -242,13 +242,10 @@ async fn run_compact_task_inner(
         new_history =
             insert_initial_context_before_last_real_user_or_summary(new_history, initial_context);
     }
-    let mut authoritative_items = Vec::new();
-    if let Some(thread_memory_item) = thread_memory_item {
-        authoritative_items.push(thread_memory_item);
-    }
-    if let Some(continuation_bridge_item) = continuation_bridge_item {
-        authoritative_items.push(continuation_bridge_item);
-    }
+    let authoritative_items: Vec<_> = thread_memory_item
+        .into_iter()
+        .chain(continuation_bridge_item)
+        .collect();
     if !authoritative_items.is_empty() {
         new_history =
             insert_items_before_last_summary_or_compaction(new_history, authoritative_items);

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -9,9 +9,11 @@ use crate::codex::PreviousTurnSettings;
 use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex::get_last_assistant_message_from_turn;
+use crate::config::GovernancePathVariant;
 use crate::continuation_bridge::generate_continuation_bridge_item;
 use crate::error::CodexErr;
 use crate::error::Result as CodexResult;
+use crate::governance::thread_memory::generate_thread_memory_item;
 use crate::protocol::CompactedItem;
 use crate::protocol::EventMsg;
 use crate::protocol::TurnStartedEvent;
@@ -101,12 +103,31 @@ async fn run_compact_task_inner(
     let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input);
 
     let mut history = sess.clone_history().await;
+    let history_for_artifacts = history
+        .clone()
+        .for_prompt(&turn_context.model_info.input_modalities);
+    let thread_memory_item = if turn_context.governance_path_variant() == GovernancePathVariant::Off
+    {
+        None
+    } else {
+        match generate_thread_memory_item(
+            &sess,
+            turn_context.as_ref(),
+            history_for_artifacts.clone(),
+        )
+        .await
+        {
+            Ok(item) => item,
+            Err(err) => {
+                warn!("failed generating thread memory before local compaction: {err}");
+                None
+            }
+        }
+    };
     let continuation_bridge_item = match generate_continuation_bridge_item(
         &sess,
         turn_context.as_ref(),
-        history
-            .clone()
-            .for_prompt(&turn_context.model_info.input_modalities),
+        history_for_artifacts,
     )
     .await
     {
@@ -221,11 +242,16 @@ async fn run_compact_task_inner(
         new_history =
             insert_initial_context_before_last_real_user_or_summary(new_history, initial_context);
     }
+    let mut authoritative_items = Vec::new();
+    if let Some(thread_memory_item) = thread_memory_item {
+        authoritative_items.push(thread_memory_item);
+    }
     if let Some(continuation_bridge_item) = continuation_bridge_item {
-        new_history = insert_items_before_last_summary_or_compaction(
-            new_history,
-            vec![continuation_bridge_item],
-        );
+        authoritative_items.push(continuation_bridge_item);
+    }
+    if !authoritative_items.is_empty() {
+        new_history =
+            insert_items_before_last_summary_or_compaction(new_history, authoritative_items);
     }
     let ghost_snapshots: Vec<ResponseItem> = history_items
         .iter()

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -8,6 +8,7 @@ use crate::codex::built_tools;
 use crate::compact::InitialContextInjection;
 use crate::compact::insert_initial_context_before_last_real_user_or_summary;
 use crate::compact::insert_items_before_last_summary_or_compaction;
+use crate::config::GovernancePathVariant;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::context_manager::estimate_response_item_model_visible_bytes;
@@ -15,6 +16,7 @@ use crate::context_manager::is_codex_generated_item;
 use crate::continuation_bridge::generate_continuation_bridge_item;
 use crate::error::CodexErr;
 use crate::error::Result as CodexResult;
+use crate::governance::thread_memory::generate_thread_memory_item;
 use crate::protocol::CompactedItem;
 use crate::protocol::EventMsg;
 use crate::protocol::TurnStartedEvent;
@@ -116,6 +118,24 @@ async fn run_remote_compact_task_inner_impl(
         personality: turn_context.personality,
         output_schema: None,
     };
+    let thread_memory_item = if turn_context.governance_path_variant() == GovernancePathVariant::Off
+    {
+        None
+    } else {
+        match generate_thread_memory_item(
+            sess.as_ref(),
+            turn_context.as_ref(),
+            prompt.input.clone(),
+        )
+        .await
+        {
+            Ok(item) => item,
+            Err(err) => {
+                warn!("failed generating thread memory before remote compaction: {err}");
+                None
+            }
+        }
+    };
     let continuation_bridge_item = match generate_continuation_bridge_item(
         sess.as_ref(),
         turn_context.as_ref(),
@@ -160,11 +180,16 @@ async fn run_remote_compact_task_inner_impl(
         initial_context_injection,
     )
     .await;
+    let mut authoritative_items = Vec::new();
+    if let Some(thread_memory_item) = thread_memory_item {
+        authoritative_items.push(thread_memory_item);
+    }
     if let Some(continuation_bridge_item) = continuation_bridge_item {
-        new_history = insert_items_before_last_summary_or_compaction(
-            new_history,
-            vec![continuation_bridge_item],
-        );
+        authoritative_items.push(continuation_bridge_item);
+    }
+    if !authoritative_items.is_empty() {
+        new_history =
+            insert_items_before_last_summary_or_compaction(new_history, authoritative_items);
     }
 
     if !ghost_snapshots.is_empty() {

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -180,13 +180,10 @@ async fn run_remote_compact_task_inner_impl(
         initial_context_injection,
     )
     .await;
-    let mut authoritative_items = Vec::new();
-    if let Some(thread_memory_item) = thread_memory_item {
-        authoritative_items.push(thread_memory_item);
-    }
-    if let Some(continuation_bridge_item) = continuation_bridge_item {
-        authoritative_items.push(continuation_bridge_item);
-    }
+    let authoritative_items: Vec<_> = thread_memory_item
+        .into_iter()
+        .chain(continuation_bridge_item)
+        .collect();
     if !authoritative_items.is_empty() {
         new_history =
             insert_items_before_last_summary_or_compaction(new_history, authoritative_items);

--- a/codex-rs/core/src/governance/mod.rs
+++ b/codex-rs/core/src/governance/mod.rs
@@ -1,4 +1,5 @@
 pub mod compiler;
 pub mod diagnostics;
 pub mod packets;
+pub mod thread_memory;
 pub mod transitions;

--- a/codex-rs/core/src/governance/thread_memory.rs
+++ b/codex-rs/core/src/governance/thread_memory.rs
@@ -1,0 +1,411 @@
+use crate::Prompt;
+use crate::codex::Session;
+use crate::codex::TurnContext;
+use crate::error::Result;
+use codex_api::ResponseEvent;
+use codex_protocol::models::BaseInstructions;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::ResponseItem;
+use futures::StreamExt;
+use serde_json::Value;
+use std::io;
+use tracing::warn;
+
+pub(crate) const SCHEMA: &str = "odeu_thread_memory_v1";
+pub(crate) const PROMPT: &str = include_str!("../../templates/thread_memory/prompt.md");
+const OUTPUT_SCHEMA: &str = include_str!("../../templates/thread_memory/schema.json");
+
+const THREAD_MEMORY_TAG: &str = "thread_memory";
+const MAX_SOURCE_ITEMS: usize = 160;
+
+pub(crate) fn output_schema() -> Value {
+    match serde_json::from_str(OUTPUT_SCHEMA) {
+        Ok(value) => value,
+        Err(err) => panic!("invalid thread memory schema artifact: {err}"),
+    }
+}
+
+pub(crate) async fn generate_thread_memory_item(
+    sess: &Session,
+    turn_context: &TurnContext,
+    input: Vec<ResponseItem>,
+) -> Result<Option<ResponseItem>> {
+    if input.is_empty() {
+        return Ok(None);
+    }
+
+    let (previous_memory, source_items) = split_previous_memory_and_source_items(&input);
+    if source_items.is_empty()
+        && let Some(previous_memory) = previous_memory
+    {
+        return Ok(Some(thread_memory_response_item(previous_memory)?));
+    }
+
+    let (mut source_items, trimmed_source_count) = limit_source_items(source_items);
+    if source_items.is_empty() && previous_memory.is_none() {
+        return Ok(None);
+    }
+
+    source_items.push(ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: build_update_message(
+                previous_memory.as_ref(),
+                source_items.len(),
+                trimmed_source_count,
+            ),
+        }],
+        end_turn: None,
+        phase: None,
+    });
+
+    let prompt = Prompt {
+        input: source_items,
+        tools: Vec::new(),
+        parallel_tool_calls: false,
+        base_instructions: BaseInstructions {
+            text: sess.get_base_instructions().await.text,
+        },
+        personality: turn_context.personality,
+        output_schema: Some(output_schema()),
+    };
+    let turn_metadata_header = turn_context.turn_metadata_state.current_header_value();
+    let mut client_session = sess.services.model_client.new_session();
+    let mut stream = client_session
+        .stream(
+            &prompt,
+            &turn_context.model_info,
+            &turn_context.session_telemetry,
+            turn_context.reasoning_effort,
+            turn_context.reasoning_summary,
+            turn_context.config.service_tier,
+            turn_metadata_header.as_deref(),
+        )
+        .await?;
+
+    let mut result = String::new();
+    while let Some(message) = stream.next().await.transpose()? {
+        match message {
+            ResponseEvent::OutputTextDelta(delta) => result.push_str(&delta),
+            ResponseEvent::OutputItemDone(item) => {
+                if result.is_empty()
+                    && let ResponseItem::Message { content, .. } = item
+                    && let Some(text) = crate::compact::content_items_to_text(&content)
+                {
+                    result.push_str(&text);
+                }
+            }
+            ResponseEvent::Completed { .. } => break,
+            ResponseEvent::Created
+            | ResponseEvent::OutputItemAdded(_)
+            | ResponseEvent::ServerModel(_)
+            | ResponseEvent::ServerReasoningIncluded(_)
+            | ResponseEvent::ReasoningSummaryDelta { .. }
+            | ResponseEvent::ReasoningContentDelta { .. }
+            | ResponseEvent::ReasoningSummaryPartAdded { .. }
+            | ResponseEvent::RateLimits(_)
+            | ResponseEvent::ModelsEtag(_) => {}
+        }
+    }
+
+    let result = result.trim();
+    if result.is_empty() {
+        return Ok(None);
+    }
+    let memory = parse_thread_memory_response(result)?;
+    Ok(Some(thread_memory_response_item(memory)?))
+}
+
+fn split_previous_memory_and_source_items(
+    input: &[ResponseItem],
+) -> (Option<Value>, Vec<ResponseItem>) {
+    for (index, item) in input.iter().enumerate().rev() {
+        if let Some(payload) = extract_thread_memory_payload(item) {
+            match serde_json::from_str::<Value>(&payload) {
+                Ok(memory) => {
+                    let source_items = input.iter().skip(index + 1).cloned().collect();
+                    return (Some(memory), source_items);
+                }
+                Err(err) => {
+                    warn!("failed parsing previous thread memory payload; ignoring: {err}");
+                }
+            }
+        }
+    }
+
+    (None, input.to_vec())
+}
+
+fn limit_source_items(source_items: Vec<ResponseItem>) -> (Vec<ResponseItem>, usize) {
+    let source_items_len = source_items.len();
+    if source_items_len <= MAX_SOURCE_ITEMS {
+        return (source_items, 0);
+    }
+
+    let start = source_items_len - MAX_SOURCE_ITEMS;
+    (source_items.into_iter().skip(start).collect(), start)
+}
+
+fn build_update_message(
+    previous_memory: Option<&Value>,
+    source_items_count: usize,
+    trimmed_source_count: usize,
+) -> String {
+    let mut message = format!(
+        "{PROMPT}\n\n<thread_memory_update_context>\nsource_items_count={source_items_count}\ntrimmed_source_items={trimmed_source_count}\n</thread_memory_update_context>"
+    );
+    if let Some(previous_memory) = previous_memory
+        && let Ok(previous_memory_json) = serde_json::to_string_pretty(previous_memory)
+    {
+        message.push_str("\n\n<previous_thread_memory_json>\n");
+        message.push_str(&previous_memory_json);
+        message.push_str("\n</previous_thread_memory_json>");
+    }
+
+    message
+}
+
+fn parse_thread_memory_response(result: &str) -> Result<Value> {
+    let mut stream = serde_json::Deserializer::from_str(result).into_iter::<Value>();
+    let mut value = match stream.next() {
+        Some(Ok(value)) => value,
+        Some(Err(err)) => {
+            let response_chars = result.chars().count();
+            let preview = preview_text(result, /*max_chars*/ 1_024);
+            warn!(
+                "failed parsing thread memory response: {err}; response_chars={response_chars}; response_preview={preview:?}"
+            );
+            return Err(err.into());
+        }
+        None => {
+            return Ok(serde_json::json!({ "schema": SCHEMA }));
+        }
+    };
+
+    let trailing = result[stream.byte_offset()..].trim();
+    if !trailing.is_empty() {
+        let trailing_chars = trailing.chars().count();
+        let trailing_preview = preview_text(trailing, /*max_chars*/ 512);
+        warn!(
+            "ignoring trailing content after thread memory JSON: trailing_chars={trailing_chars}; trailing_preview={trailing_preview:?}"
+        );
+    }
+
+    if !value.is_object() {
+        let err = serde_json::Error::io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "thread memory response must be a JSON object",
+        ));
+        return Err(err.into());
+    }
+
+    normalize_schema(&mut value);
+    Ok(value)
+}
+
+fn normalize_schema(memory: &mut Value) -> String {
+    let schema = memory
+        .get("schema")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|schema| !schema.is_empty())
+        .unwrap_or(SCHEMA)
+        .to_string();
+    memory["schema"] = Value::String(schema.clone());
+    schema
+}
+
+fn thread_memory_response_item(mut memory: Value) -> Result<ResponseItem> {
+    let schema = normalize_schema(&mut memory);
+    let memory_json = serde_json::to_string_pretty(&memory)?;
+    Ok(ResponseItem::Message {
+        id: None,
+        role: "developer".to_string(),
+        content: vec![ContentItem::InputText {
+            text: format!(
+                "<{THREAD_MEMORY_TAG} schema=\"{schema}\">\n{memory_json}\n</{THREAD_MEMORY_TAG}>"
+            ),
+        }],
+        end_turn: None,
+        phase: None,
+    })
+}
+
+fn extract_thread_memory_payload(item: &ResponseItem) -> Option<String> {
+    let ResponseItem::Message { role, content, .. } = item else {
+        return None;
+    };
+    if role != "developer" {
+        return None;
+    }
+
+    let text = crate::compact::content_items_to_text(content)?;
+    let payload = extract_tagged_payload(&text, THREAD_MEMORY_TAG)?;
+    Some(payload.to_string())
+}
+
+fn extract_tagged_payload<'a>(text: &'a str, tag: &str) -> Option<&'a str> {
+    let open_tag_prefix = format!("<{tag}");
+    let close_tag = format!("</{tag}>");
+    let open_index = text.find(&open_tag_prefix)?;
+    let open_tag_end = text[open_index..].find('>')? + open_index + 1;
+    let close_index = text[open_tag_end..].find(&close_tag)? + open_tag_end;
+    let payload = text[open_tag_end..close_index].trim();
+    if payload.is_empty() {
+        None
+    } else {
+        Some(payload)
+    }
+}
+
+fn preview_text(text: &str, max_chars: usize) -> String {
+    let mut chars = text.chars();
+    let preview: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{preview}...")
+    } else {
+        preview
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SCHEMA;
+    use super::THREAD_MEMORY_TAG;
+    use super::extract_tagged_payload;
+    use super::output_schema;
+    use super::parse_thread_memory_response;
+    use super::split_previous_memory_and_source_items;
+    use super::thread_memory_response_item;
+    use codex_protocol::models::ContentItem;
+    use codex_protocol::models::ResponseItem;
+    use pretty_assertions::assert_eq;
+
+    fn user_message(text: &str) -> ResponseItem {
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: text.to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        }
+    }
+
+    fn thread_memory_item(memory_json: &str) -> ResponseItem {
+        ResponseItem::Message {
+            id: None,
+            role: "developer".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!(
+                    "<{THREAD_MEMORY_TAG} schema=\"{SCHEMA}\">\n{memory_json}\n</{THREAD_MEMORY_TAG}>"
+                ),
+            }],
+            end_turn: None,
+            phase: None,
+        }
+    }
+
+    #[test]
+    fn output_schema_uses_artifact() {
+        let schema = output_schema();
+        let artifact: serde_json::Value = serde_json::from_str(super::OUTPUT_SCHEMA)
+            .unwrap_or_else(|err| panic!("schema artifact should parse: {err}"));
+
+        assert_eq!(schema, artifact);
+        assert_eq!(
+            schema["properties"]["schema"]["enum"][0].as_str(),
+            Some(SCHEMA)
+        );
+    }
+
+    #[test]
+    fn extract_tagged_payload_returns_body() {
+        let tagged = format!(
+            "<{THREAD_MEMORY_TAG} schema=\"{SCHEMA}\">\n{{\"schema\":\"{SCHEMA}\"}}\n</{THREAD_MEMORY_TAG}>"
+        );
+
+        let payload = extract_tagged_payload(&tagged, THREAD_MEMORY_TAG);
+
+        assert_eq!(payload, Some("{\"schema\":\"odeu_thread_memory_v1\"}"));
+    }
+
+    #[test]
+    fn split_previous_memory_uses_latest_marker() {
+        let first = serde_json::json!({
+            "schema": SCHEMA,
+            "thread": { "compaction_epoch": 0 }
+        })
+        .to_string();
+        let second = serde_json::json!({
+            "schema": SCHEMA,
+            "thread": { "compaction_epoch": 1 }
+        })
+        .to_string();
+        let input = vec![
+            user_message("old message"),
+            thread_memory_item(&first),
+            user_message("delta one"),
+            thread_memory_item(&second),
+            user_message("delta two"),
+        ];
+
+        let (previous, source_items) = split_previous_memory_and_source_items(&input);
+
+        assert_eq!(
+            previous,
+            Some(serde_json::json!({
+                "schema": SCHEMA,
+                "thread": { "compaction_epoch": 1 }
+            }))
+        );
+        assert_eq!(source_items, vec![user_message("delta two")]);
+    }
+
+    #[test]
+    fn parse_thread_memory_response_ignores_trailing_text() {
+        let payload = serde_json::json!({
+            "schema": SCHEMA,
+            "thread": {},
+            "thread_odeu": {},
+            "routing": {},
+            "subjects": [],
+            "continuity": {},
+            "recent_delta": {},
+            "turn_projection": {}
+        });
+        let raw = format!("{payload}\ntrailing text");
+
+        let parsed = parse_thread_memory_response(&raw).expect("thread memory should parse");
+
+        assert_eq!(parsed["schema"].as_str(), Some(SCHEMA));
+    }
+
+    #[test]
+    fn thread_memory_response_item_defaults_schema_when_missing() {
+        let item = thread_memory_response_item(serde_json::json!({
+            "thread": {}
+        }))
+        .expect("thread memory item");
+        let expected = ResponseItem::Message {
+            id: None,
+            role: "developer".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!(
+                    "<{THREAD_MEMORY_TAG} schema=\"{SCHEMA}\">\n{}\n</{THREAD_MEMORY_TAG}>",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "schema": SCHEMA,
+                        "thread": {}
+                    }))
+                    .expect("json")
+                ),
+            }],
+            end_turn: None,
+            phase: None,
+        };
+
+        assert_eq!(item, expected);
+    }
+}

--- a/codex-rs/core/src/governance/thread_memory.rs
+++ b/codex-rs/core/src/governance/thread_memory.rs
@@ -124,7 +124,12 @@ fn split_previous_memory_and_source_items(
         if let Some(payload) = extract_thread_memory_payload(item) {
             match serde_json::from_str::<Value>(&payload) {
                 Ok(memory) => {
-                    let source_items = input.iter().skip(index + 1).cloned().collect();
+                    let source_items = input
+                        .iter()
+                        .skip(index + 1)
+                        .filter(|item| should_include_delta_source_item(item))
+                        .cloned()
+                        .collect();
                     return (Some(memory), source_items);
                 }
                 Err(err) => {
@@ -135,6 +140,29 @@ fn split_previous_memory_and_source_items(
     }
 
     (None, input.to_vec())
+}
+
+fn should_include_delta_source_item(item: &ResponseItem) -> bool {
+    match item {
+        ResponseItem::Compaction { .. } | ResponseItem::GhostSnapshot { .. } => false,
+        ResponseItem::Message { role, content, .. } if role == "developer" => {
+            let Some(text) = crate::compact::content_items_to_text(content) else {
+                return true;
+            };
+
+            extract_tagged_payload(&text, THREAD_MEMORY_TAG).is_none()
+                && extract_tagged_payload(&text, "continuation_bridge").is_none()
+        }
+        ResponseItem::Message { role, content, .. } if role == "user" => {
+            let Some(text) = crate::compact::content_items_to_text(content) else {
+                return true;
+            };
+            !text
+                .trim_start()
+                .starts_with(crate::compact::SUMMARY_PREFIX.trim_end())
+        }
+        _ => true,
+    }
 }
 
 fn limit_source_items(source_items: Vec<ResponseItem>) -> (Vec<ResponseItem>, usize) {
@@ -276,6 +304,7 @@ mod tests {
     use super::extract_tagged_payload;
     use super::output_schema;
     use super::parse_thread_memory_response;
+    use super::should_include_delta_source_item;
     use super::split_previous_memory_and_source_items;
     use super::thread_memory_response_item;
     use codex_protocol::models::ContentItem;
@@ -302,6 +331,30 @@ mod tests {
                 text: format!(
                     "<{THREAD_MEMORY_TAG} schema=\"{SCHEMA}\">\n{memory_json}\n</{THREAD_MEMORY_TAG}>"
                 ),
+            }],
+            end_turn: None,
+            phase: None,
+        }
+    }
+
+    fn continuation_bridge_item() -> ResponseItem {
+        ResponseItem::Message {
+            id: None,
+            role: "developer".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "<continuation_bridge schema=\"continuation_bridge_baton_v1\">\n{}\n</continuation_bridge>".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        }
+    }
+
+    fn compaction_summary_item() -> ResponseItem {
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!("{}\nsummary", crate::compact::SUMMARY_PREFIX.trim_end()),
             }],
             end_turn: None,
             phase: None,
@@ -362,6 +415,102 @@ mod tests {
             }))
         );
         assert_eq!(source_items, vec![user_message("delta two")]);
+    }
+
+    #[test]
+    fn split_previous_memory_ignores_prior_compaction_artifacts_after_marker() {
+        let prior_memory = serde_json::json!({
+            "schema": SCHEMA,
+            "thread": { "compaction_epoch": 2 }
+        })
+        .to_string();
+        let input = vec![
+            thread_memory_item(&prior_memory),
+            continuation_bridge_item(),
+            compaction_summary_item(),
+            ResponseItem::Compaction {
+                encrypted_content: "encrypted".to_string(),
+            },
+        ];
+
+        let (previous, source_items) = split_previous_memory_and_source_items(&input);
+
+        assert_eq!(
+            previous,
+            Some(serde_json::json!({
+                "schema": SCHEMA,
+                "thread": { "compaction_epoch": 2 }
+            }))
+        );
+        assert_eq!(source_items, Vec::<ResponseItem>::new());
+    }
+
+    #[test]
+    fn split_previous_memory_keeps_real_delta_after_compaction_artifacts() {
+        let prior_memory = serde_json::json!({
+            "schema": SCHEMA,
+            "thread": { "compaction_epoch": 3 }
+        })
+        .to_string();
+        let input = vec![
+            thread_memory_item(&prior_memory),
+            continuation_bridge_item(),
+            compaction_summary_item(),
+            ResponseItem::Compaction {
+                encrypted_content: "encrypted".to_string(),
+            },
+            user_message("new user request"),
+            ResponseItem::Message {
+                id: None,
+                role: "assistant".to_string(),
+                content: vec![ContentItem::OutputText {
+                    text: "new assistant reply".to_string(),
+                }],
+                end_turn: None,
+                phase: None,
+            },
+        ];
+
+        let (previous, source_items) = split_previous_memory_and_source_items(&input);
+
+        assert_eq!(
+            previous,
+            Some(serde_json::json!({
+                "schema": SCHEMA,
+                "thread": { "compaction_epoch": 3 }
+            }))
+        );
+        assert_eq!(
+            source_items,
+            vec![
+                user_message("new user request"),
+                ResponseItem::Message {
+                    id: None,
+                    role: "assistant".to_string(),
+                    content: vec![ContentItem::OutputText {
+                        text: "new assistant reply".to_string(),
+                    }],
+                    end_turn: None,
+                    phase: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn delta_source_filter_drops_compaction_summary_and_bridge_artifacts() {
+        assert!(!should_include_delta_source_item(
+            &continuation_bridge_item()
+        ));
+        assert!(!should_include_delta_source_item(&compaction_summary_item()));
+        assert!(!should_include_delta_source_item(
+            &ResponseItem::Compaction {
+                encrypted_content: "encrypted".to_string(),
+            }
+        ));
+        assert!(should_include_delta_source_item(&user_message(
+            "actual delta"
+        )));
     }
 
     #[test]

--- a/codex-rs/core/templates/thread_memory/prompt.md
+++ b/codex-rs/core/templates/thread_memory/prompt.md
@@ -1,0 +1,23 @@
+You are maintaining canonical thread memory for compaction handoff.
+
+Produce one JSON object that strictly matches the provided schema.
+
+Core policy:
+- Preserve claim/state continuity, not conversational narration.
+- User corrections override assistant-originated claims.
+- If `<previous_thread_memory_json>` is present, treat it as the canonical base and update it.
+- Apply only the delta represented by source items in this request.
+- Keep subject identities stable (`subject_id`) when concepts persist.
+- Keep entries concise and load-bearing.
+
+Update protocol:
+1. Carry forward still-valid state from previous memory.
+2. Merge new facts/decisions/constraints/uncertainties from the source items.
+3. Update `continuity` and `recent_delta` to reflect what changed in this update.
+4. Keep `turn_projection.clusters` structural (decisions/state changes), not prose recap.
+5. Prefer explicit uncertainty fields over speculative assertions.
+
+Output constraints:
+- Return JSON only, no markdown.
+- Do not omit required fields from the schema.
+- Do not include transcript excerpts unless they are needed as compact structural claims.

--- a/codex-rs/core/templates/thread_memory/schema.json
+++ b/codex-rs/core/templates/thread_memory/schema.json
@@ -1,0 +1,417 @@
+{
+  "type": "object",
+  "properties": {
+    "schema": {
+      "type": "string",
+      "enum": ["odeu_thread_memory_v1"]
+    },
+    "thread": {
+      "type": "object",
+      "properties": {
+        "thread_id": { "type": "string" },
+        "title": { "type": "string" },
+        "status": { "type": "string" },
+        "compaction_epoch": { "type": "integer", "minimum": 0 },
+        "source_turn_range": {
+          "type": "object",
+          "properties": {
+            "from": { "type": "integer", "minimum": 0 },
+            "to": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["from", "to"],
+          "additionalProperties": false
+        },
+        "previous_memory_hash": { "type": ["string", "null"] }
+      },
+      "required": [
+        "thread_id",
+        "title",
+        "status",
+        "compaction_epoch",
+        "source_turn_range",
+        "previous_memory_hash"
+      ],
+      "additionalProperties": false
+    },
+    "thread_odeu": {
+      "type": "object",
+      "properties": {
+        "o": {
+          "type": "object",
+          "properties": {
+            "project": { "type": "string" },
+            "domain": { "type": "string" },
+            "active_contexts": { "type": "array", "items": { "type": "string" } }
+          },
+          "required": ["project", "domain", "active_contexts"],
+          "additionalProperties": false
+        },
+        "e": {
+          "type": "object",
+          "properties": {
+            "source_priority": { "type": "array", "items": { "type": "string" } },
+            "standing_uncertainties": { "type": "array", "items": { "type": "string" } }
+          },
+          "required": ["source_priority", "standing_uncertainties"],
+          "additionalProperties": false
+        },
+        "d": {
+          "type": "object",
+          "properties": {
+            "global_constraints": { "type": "array", "items": { "type": "string" } },
+            "global_non_goals": { "type": "array", "items": { "type": "string" } }
+          },
+          "required": ["global_constraints", "global_non_goals"],
+          "additionalProperties": false
+        },
+        "u": {
+          "type": "object",
+          "properties": {
+            "global_objectives": { "type": "array", "items": { "type": "string" } },
+            "global_pain_points": { "type": "array", "items": { "type": "string" } }
+          },
+          "required": ["global_objectives", "global_pain_points"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["o", "e", "d", "u"],
+      "additionalProperties": false
+    },
+    "routing": {
+      "type": "object",
+      "properties": {
+        "active_subject_ids": { "type": "array", "items": { "type": "string" } },
+        "recent_subject_ids": { "type": "array", "items": { "type": "string" } },
+        "continuation_mode": { "type": "string" },
+        "subject_switches": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": [
+        "active_subject_ids",
+        "recent_subject_ids",
+        "continuation_mode",
+        "subject_switches"
+      ],
+      "additionalProperties": false
+    },
+    "subjects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "subject_id": { "type": "string" },
+          "label": { "type": "string" },
+          "kind": { "type": "string" },
+          "status": { "type": "string" },
+          "introduced_at_turn": { "type": "integer", "minimum": 0 },
+          "last_touched_turn": { "type": "integer", "minimum": 0 },
+          "routing_cues": { "type": "array", "items": { "type": "string" } },
+          "anchor_summary": { "type": "string" },
+          "o": {
+            "type": "object",
+            "properties": {
+              "entities": { "type": "array", "items": { "type": "string" } },
+              "artifacts": { "type": "array", "items": { "type": "string" } },
+              "states": { "type": "array", "items": { "type": "string" } },
+              "boundaries": { "type": "array", "items": { "type": "string" } },
+              "subsubjects": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["entities", "artifacts", "states", "boundaries", "subsubjects"],
+            "additionalProperties": false
+          },
+          "e": {
+            "type": "object",
+            "properties": {
+              "established": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "claim": { "type": "string" },
+                    "strength": { "type": "string" },
+                    "source_turns": { "type": "array", "items": { "type": "integer" } },
+                    "witness_refs": { "type": "array", "items": { "type": "string" } }
+                  },
+                  "required": ["id", "claim", "strength", "source_turns", "witness_refs"],
+                  "additionalProperties": false
+                }
+              },
+              "uncertainties": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "kind": { "type": "string" },
+                    "description": { "type": "string" },
+                    "blocking": { "type": "boolean" },
+                    "source_turns": { "type": "array", "items": { "type": "integer" } }
+                  },
+                  "required": ["id", "kind", "description", "blocking", "source_turns"],
+                  "additionalProperties": false
+                }
+              },
+              "witnesses": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "type": { "type": "string" },
+                    "description": { "type": "string" },
+                    "freshness": { "type": "string" },
+                    "source_turns": { "type": "array", "items": { "type": "integer" } }
+                  },
+                  "required": ["id", "type", "description", "freshness", "source_turns"],
+                  "additionalProperties": false
+                }
+              },
+              "decision_rules": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["established", "uncertainties", "witnesses", "decision_rules"],
+            "additionalProperties": false
+          },
+          "d": {
+            "type": "object",
+            "properties": {
+              "active_constraints": { "type": "array", "items": { "type": "string" } },
+              "forbidden_moves": { "type": "array", "items": { "type": "string" } },
+              "required_sequence": { "type": "array", "items": { "type": "string" } },
+              "accepted_protocols": { "type": "array", "items": { "type": "string" } },
+              "completion_conditions": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": [
+              "active_constraints",
+              "forbidden_moves",
+              "required_sequence",
+              "accepted_protocols",
+              "completion_conditions"
+            ],
+            "additionalProperties": false
+          },
+          "u": {
+            "type": "object",
+            "properties": {
+              "user_goals": { "type": "array", "items": { "type": "string" } },
+              "success_criteria": { "type": "array", "items": { "type": "string" } },
+              "pain_points": { "type": "array", "items": { "type": "string" } },
+              "optimization_targets": { "type": "array", "items": { "type": "string" } },
+              "non_goals": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": [
+              "user_goals",
+              "success_criteria",
+              "pain_points",
+              "optimization_targets",
+              "non_goals"
+            ],
+            "additionalProperties": false
+          },
+          "inferential_state": {
+            "type": "object",
+            "properties": {
+              "accepted_claims": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "text": { "type": "string" },
+                    "source_turns": { "type": "array", "items": { "type": "integer" } },
+                    "depends_on": { "type": "array", "items": { "type": "string" } }
+                  },
+                  "required": ["id", "text", "source_turns", "depends_on"],
+                  "additionalProperties": false
+                }
+              },
+              "open_questions": { "type": "array", "items": { "type": "string" } },
+              "rejected_paths": { "type": "array", "items": { "type": "string" } },
+              "next_decisions": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": [
+              "accepted_claims",
+              "open_questions",
+              "rejected_paths",
+              "next_decisions"
+            ],
+            "additionalProperties": false
+          },
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "kind": { "type": "string" },
+                "status": { "type": "string" },
+                "source_turns": { "type": "array", "items": { "type": "integer" } }
+              },
+              "required": ["name", "kind", "status", "source_turns"],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "subject_id",
+          "label",
+          "kind",
+          "status",
+          "introduced_at_turn",
+          "last_touched_turn",
+          "routing_cues",
+          "anchor_summary",
+          "o",
+          "e",
+          "d",
+          "u",
+          "inferential_state",
+          "artifacts"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "continuity": {
+      "type": "object",
+      "properties": {
+        "open_loops": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "subject_id": { "type": "string" },
+              "description": { "type": "string" },
+              "status": { "type": "string" },
+              "needed_for_continuation": { "type": "boolean" }
+            },
+            "required": ["id", "subject_id", "description", "status", "needed_for_continuation"],
+            "additionalProperties": false
+          }
+        },
+        "latest_decisions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "subject_id": { "type": "string" },
+              "decision": { "type": "string" },
+              "status": { "type": "string" },
+              "source_turns": { "type": "array", "items": { "type": "integer" } }
+            },
+            "required": ["id", "subject_id", "decision", "status", "source_turns"],
+            "additionalProperties": false
+          }
+        },
+        "active_blockers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "subject_id": { "type": "string" },
+              "kind": { "type": "string" },
+              "description": { "type": "string" }
+            },
+            "required": ["subject_id", "kind", "description"],
+            "additionalProperties": false
+          }
+        },
+        "next_expected_moves": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["open_loops", "latest_decisions", "active_blockers", "next_expected_moves"],
+      "additionalProperties": false
+    },
+    "recent_delta": {
+      "type": "object",
+      "properties": {
+        "since_turn": { "type": "integer", "minimum": 0 },
+        "new_subject_ids": { "type": "array", "items": { "type": "string" } },
+        "updated_subject_ids": { "type": "array", "items": { "type": "string" } },
+        "closed_subject_ids": { "type": "array", "items": { "type": "string" } },
+        "new_artifacts": { "type": "array", "items": { "type": "string" } },
+        "new_decisions": { "type": "array", "items": { "type": "string" } },
+        "resolved_uncertainties": { "type": "array", "items": { "type": "string" } },
+        "new_uncertainties": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": [
+        "since_turn",
+        "new_subject_ids",
+        "updated_subject_ids",
+        "closed_subject_ids",
+        "new_artifacts",
+        "new_decisions",
+        "resolved_uncertainties",
+        "new_uncertainties"
+      ],
+      "additionalProperties": false
+    },
+    "turn_projection": {
+      "type": "object",
+      "properties": {
+        "clusters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "cluster_id": { "type": "string" },
+              "turn_range": {
+                "type": "object",
+                "properties": {
+                  "from": { "type": "integer", "minimum": 0 },
+                  "to": { "type": "integer", "minimum": 0 }
+                },
+                "required": ["from", "to"],
+                "additionalProperties": false
+              },
+              "primary_subject_ids": { "type": "array", "items": { "type": "string" } },
+              "event_types": { "type": "array", "items": { "type": "string" } },
+              "odeu_delta": {
+                "type": "object",
+                "properties": {
+                  "o": { "type": "array", "items": { "type": "string" } },
+                  "e": { "type": "array", "items": { "type": "string" } },
+                  "d": { "type": "array", "items": { "type": "string" } },
+                  "u": { "type": "array", "items": { "type": "string" } }
+                },
+                "required": ["o", "e", "d", "u"],
+                "additionalProperties": false
+              },
+              "result_summary": { "type": "string" }
+            },
+            "required": [
+              "cluster_id",
+              "turn_range",
+              "primary_subject_ids",
+              "event_types",
+              "odeu_delta",
+              "result_summary"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "raw_retention_window": {
+          "type": "object",
+          "properties": {
+            "last_user_turns": { "type": "integer", "minimum": 0 },
+            "last_assistant_turns": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["last_user_turns", "last_assistant_turns"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["clusters", "raw_retention_window"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "schema",
+    "thread",
+    "thread_odeu",
+    "routing",
+    "subjects",
+    "continuity",
+    "recent_delta",
+    "turn_projection"
+  ],
+  "additionalProperties": false
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -63,8 +63,9 @@ This fork now includes strict-governance packet scaffolding behind a config gate
 - `governance_path_variant = "strict_v1_shadow"`
 - `governance_path_variant = "strict_v1_enforce"`
 
-`strict_v1_shadow` and `strict_v1_enforce` currently only configure packet/compiler scaffolding.
-They do not switch core runtime behavior yet.
+`strict_v1_shadow` and `strict_v1_enforce` now also enable a pre-compaction ODEU thread-memory
+artifact that is generated as a structured `developer` message and inserted into replacement
+history alongside the continuation bridge.
 
 ## JSON Schema
 


### PR DESCRIPTION
## Summary
- add a new strict-path `governance::thread_memory` generator that emits a structured `<thread_memory ...>` developer artifact using a schema-constrained model call
- add thread-memory prompt/schema artifacts under `codex-rs/core/templates/thread_memory/`
- wire thread-memory generation into both local and remote compaction flows, gated by `governance_path_variant != off`
- keep continuation bridge generation intact and insert both artifacts before the final summary/compaction marker
- update config docs to reflect strict variants now enabling the pre-compaction thread-memory artifact

## Validation
- `just fmt`
- `cargo test -p codex-core governance::thread_memory`
- `cargo test -p codex-core compact::tests::`
- `cargo test -p codex-core` *(fails in existing unrelated tests in this environment: `shell_snapshot::tests::timed_out_snapshot_shell_is_terminated`, `unified_exec::tests::completed_pipe_commands_preserve_exit_code`, `unified_exec::tests::unified_exec_pause_blocks_yield_timeout`)*
- `just fix -p codex-core`
- `just argument-comment-lint` *(fails: missing `bazel` in this environment)*
