### PR TITLE
strict-v1 p5: fail-closed thread memory + compact raw window

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -35,6 +35,7 @@ use tracing::warn;
 pub const SUMMARIZATION_PROMPT: &str = include_str!("../templates/compact/prompt.md");
 pub const SUMMARY_PREFIX: &str = include_str!("../templates/compact/summary_prefix.md");
 const COMPACT_USER_MESSAGE_MAX_TOKENS: usize = 20_000;
+pub(crate) const COMPACT_RAW_CONVERSATION_WINDOW_MESSAGES: usize = 5;
 
 /// Controls whether compaction replacement history must include initial context.
 ///
@@ -53,6 +54,10 @@ pub(crate) enum InitialContextInjection {
 
 pub(crate) fn should_use_remote_compact_task(provider: &ModelProviderInfo) -> bool {
     provider.is_openai()
+}
+
+pub(crate) fn is_thread_memory_required(path_variant: GovernancePathVariant) -> bool {
+    path_variant != GovernancePathVariant::Off
 }
 
 pub(crate) async fn run_inline_auto_compact_task(
@@ -106,10 +111,8 @@ async fn run_compact_task_inner(
     let history_for_artifacts = history
         .clone()
         .for_prompt(&turn_context.model_info.input_modalities);
-    let thread_memory_item = if turn_context.governance_path_variant() == GovernancePathVariant::Off
-    {
-        None
-    } else {
+    let governance_path_variant = turn_context.governance_path_variant();
+    let thread_memory_item = if is_thread_memory_required(governance_path_variant) {
         match generate_thread_memory_item(
             &sess,
             turn_context.as_ref(),
@@ -117,13 +120,22 @@ async fn run_compact_task_inner(
         )
         .await
         {
-            Ok(item) => item,
+            Ok(Some(item)) => Some(item),
+            Ok(None) => {
+                return Err(CodexErr::Fatal(format!(
+                    "required thread memory generation returned empty output before local compaction (path_variant={governance_path_variant:?})"
+                )));
+            }
             Err(err) => {
-                warn!("failed generating thread memory before local compaction: {err}");
-                None
+                return Err(CodexErr::Fatal(format!(
+                    "failed generating required thread memory before local compaction (path_variant={governance_path_variant:?}): {err}"
+                )));
             }
         }
+    } else {
+        None
     };
+    let thread_memory_present = thread_memory_item.is_some();
     let continuation_bridge_item = match generate_continuation_bridge_item(
         &sess,
         turn_context.as_ref(),
@@ -250,6 +262,12 @@ async fn run_compact_task_inner(
         new_history =
             insert_items_before_last_summary_or_compaction(new_history, authoritative_items);
     }
+    if thread_memory_present {
+        new_history = retain_recent_raw_conversation_messages(
+            new_history,
+            COMPACT_RAW_CONVERSATION_WINDOW_MESSAGES,
+        );
+    }
     let ghost_snapshots: Vec<ResponseItem> = history_items
         .iter()
         .filter(|item| matches!(item, ResponseItem::GhostSnapshot { .. }))
@@ -309,6 +327,47 @@ pub(crate) fn collect_user_messages(items: &[ResponseItem]) -> Vec<String> {
             }
             _ => None,
         })
+        .collect()
+}
+
+fn is_raw_conversation_message(item: &ResponseItem) -> bool {
+    match item {
+        ResponseItem::Message { role, .. } if role == "assistant" => true,
+        ResponseItem::Message { role, .. } if role == "user" => {
+            matches!(
+                crate::event_mapping::parse_turn_item(item),
+                Some(TurnItem::UserMessage(user)) if !is_summary_message(&user.message())
+            )
+        }
+        _ => false,
+    }
+}
+
+pub(crate) fn retain_recent_raw_conversation_messages(
+    compacted_history: Vec<ResponseItem>,
+    max_messages: usize,
+) -> Vec<ResponseItem> {
+    if compacted_history.is_empty() {
+        return compacted_history;
+    }
+
+    let mut retained = vec![true; compacted_history.len()];
+    let mut remaining = max_messages;
+    for (index, item) in compacted_history.iter().enumerate().rev() {
+        if !is_raw_conversation_message(item) {
+            continue;
+        }
+        if remaining > 0 {
+            remaining -= 1;
+            continue;
+        }
+        retained[index] = false;
+    }
+
+    compacted_history
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, item)| retained[index].then_some(item))
         .collect()
 }
 

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -122,14 +122,20 @@ async fn run_compact_task_inner(
         {
             Ok(Some(item)) => Some(item),
             Ok(None) => {
-                return Err(CodexErr::Fatal(format!(
+                let err = CodexErr::Fatal(format!(
                     "required thread memory generation returned empty output before local compaction (path_variant={governance_path_variant:?})"
-                )));
+                ));
+                sess.send_event(&turn_context, EventMsg::Error(err.to_error_event(None)))
+                    .await;
+                return Err(err);
             }
             Err(err) => {
-                return Err(CodexErr::Fatal(format!(
+                let err = CodexErr::Fatal(format!(
                     "failed generating required thread memory before local compaction (path_variant={governance_path_variant:?}): {err}"
-                )));
+                ));
+                sess.send_event(&turn_context, EventMsg::Error(err.to_error_event(None)))
+                    .await;
+                return Err(err);
             }
         }
     } else {

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -5,10 +5,12 @@ use crate::Prompt;
 use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex::built_tools;
+use crate::compact::COMPACT_RAW_CONVERSATION_WINDOW_MESSAGES;
 use crate::compact::InitialContextInjection;
 use crate::compact::insert_initial_context_before_last_real_user_or_summary;
 use crate::compact::insert_items_before_last_summary_or_compaction;
-use crate::config::GovernancePathVariant;
+use crate::compact::is_thread_memory_required;
+use crate::compact::retain_recent_raw_conversation_messages;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::context_manager::estimate_response_item_model_visible_bytes;
@@ -118,10 +120,8 @@ async fn run_remote_compact_task_inner_impl(
         personality: turn_context.personality,
         output_schema: None,
     };
-    let thread_memory_item = if turn_context.governance_path_variant() == GovernancePathVariant::Off
-    {
-        None
-    } else {
+    let governance_path_variant = turn_context.governance_path_variant();
+    let thread_memory_item = if is_thread_memory_required(governance_path_variant) {
         match generate_thread_memory_item(
             sess.as_ref(),
             turn_context.as_ref(),
@@ -129,13 +129,22 @@ async fn run_remote_compact_task_inner_impl(
         )
         .await
         {
-            Ok(item) => item,
+            Ok(Some(item)) => Some(item),
+            Ok(None) => {
+                return Err(CodexErr::Fatal(format!(
+                    "required thread memory generation returned empty output before remote compaction (path_variant={governance_path_variant:?})"
+                )));
+            }
             Err(err) => {
-                warn!("failed generating thread memory before remote compaction: {err}");
-                None
+                return Err(CodexErr::Fatal(format!(
+                    "failed generating required thread memory before remote compaction (path_variant={governance_path_variant:?}): {err}"
+                )));
             }
         }
+    } else {
+        None
     };
+    let thread_memory_present = thread_memory_item.is_some();
     let continuation_bridge_item = match generate_continuation_bridge_item(
         sess.as_ref(),
         turn_context.as_ref(),
@@ -187,6 +196,12 @@ async fn run_remote_compact_task_inner_impl(
     if !authoritative_items.is_empty() {
         new_history =
             insert_items_before_last_summary_or_compaction(new_history, authoritative_items);
+    }
+    if thread_memory_present {
+        new_history = retain_recent_raw_conversation_messages(
+            new_history,
+            COMPACT_RAW_CONVERSATION_WINDOW_MESSAGES,
+        );
     }
 
     if !ghost_snapshots.is_empty() {

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -122,6 +122,168 @@ do things
 }
 
 #[test]
+fn retain_recent_raw_conversation_messages_keeps_latest_window_and_preserves_summary() {
+    let history = vec![
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "older user".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "assistant".to_string(),
+            content: vec![ContentItem::OutputText {
+                text: "older assistant".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "latest user".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "assistant".to_string(),
+            content: vec![ContentItem::OutputText {
+                text: "latest assistant".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!("{SUMMARY_PREFIX}\nsummary"),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Compaction {
+            encrypted_content: "encrypted".to_string(),
+        },
+    ];
+
+    let retained = retain_recent_raw_conversation_messages(history, /*max_messages*/ 2);
+    let expected = vec![
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "latest user".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "assistant".to_string(),
+            content: vec![ContentItem::OutputText {
+                text: "latest assistant".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!("{SUMMARY_PREFIX}\nsummary"),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Compaction {
+            encrypted_content: "encrypted".to_string(),
+        },
+    ];
+
+    assert_eq!(retained, expected);
+}
+
+#[test]
+fn retain_recent_raw_conversation_messages_limit_zero_keeps_non_candidates() {
+    let history = vec![
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "drop user".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "assistant".to_string(),
+            content: vec![ContentItem::OutputText {
+                text: "drop assistant".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "developer".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "keep developer".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!("{SUMMARY_PREFIX}\nsummary"),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Compaction {
+            encrypted_content: "encrypted".to_string(),
+        },
+    ];
+
+    let retained = retain_recent_raw_conversation_messages(history, /*max_messages*/ 0);
+    let expected = vec![
+        ResponseItem::Message {
+            id: None,
+            role: "developer".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "keep developer".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!("{SUMMARY_PREFIX}\nsummary"),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Compaction {
+            encrypted_content: "encrypted".to_string(),
+        },
+    ];
+
+    assert_eq!(retained, expected);
+}
+
+#[test]
 fn build_token_limited_compacted_history_truncates_overlong_user_messages() {
     // Use a small truncation limit so the test remains fast while still validating
     // that oversized user content is truncated.


### PR DESCRIPTION
## Summary
- make governed thread-memory generation fail-closed during compaction (both local and remote paths)
- treat missing/failed thread-memory generation as fatal when governance mode is enabled, so inspection failures are explicit
- trim preserved raw conversation messages to a fixed recent window when thread-memory is present, while preserving non-conversation artifacts
- add focused tests for raw-conversation windowing behavior and summary preservation

## Details
- `compact.rs`
  - add `COMPACT_RAW_CONVERSATION_WINDOW_MESSAGES` (`5`)
  - add `is_thread_memory_required(...)`
  - switch governed thread-memory generation to fatal error on `Ok(None)` or `Err(...)`
  - add raw-conversation candidate detection + retention helper (`retain_recent_raw_conversation_messages`)
- `compact_remote.rs`
  - apply the same fail-closed governed thread-memory semantics
  - apply the same raw-conversation trimming after authoritative insertions
- `compact_tests.rs`
  - add tests validating latest-window retention and preservation of summary/non-candidate entries

## Validation
- `just fix -p codex-core`
- `./tools/argument-comment-lint/run.py -p codex-core`

## Notes
- Unrelated pre-existing `cargo test -p codex-core` failures were observed earlier on this branch in:
  - `shell_snapshot::tests::timed_out_snapshot_shell_is_terminated`
  - `unified_exec::tests::completed_pipe_commands_preserve_exit_code`
  - `unified_exec::tests::unified_exec_pause_blocks_yield_timeout`
