### PR TITLE
[codex] contain thread-spawned subagent tool surface

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -125,16 +125,22 @@ async fn run_compact_task_inner(
                 let err = CodexErr::Fatal(format!(
                     "required thread memory generation returned empty output before local compaction (path_variant={governance_path_variant:?})"
                 ));
-                sess.send_event(&turn_context, EventMsg::Error(err.to_error_event(None)))
-                    .await;
+                sess.send_event(
+                    &turn_context,
+                    EventMsg::Error(err.to_error_event(/*message_prefix*/ None)),
+                )
+                .await;
                 return Err(err);
             }
             Err(err) => {
                 let err = CodexErr::Fatal(format!(
                     "failed generating required thread memory before local compaction (path_variant={governance_path_variant:?}): {err}"
                 ));
-                sess.send_event(&turn_context, EventMsg::Error(err.to_error_event(None)))
-                    .await;
+                sess.send_event(
+                    &turn_context,
+                    EventMsg::Error(err.to_error_event(/*message_prefix*/ None)),
+                )
+                .await;
                 return Err(err);
             }
         }

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -167,6 +167,7 @@ pub(crate) struct ToolsConfig {
     pub js_repl_tools_only: bool,
     pub can_request_original_image_detail: bool,
     pub collab_tools: bool,
+    pub spawn_agent_tool: bool,
     pub multi_agent_v2: bool,
     pub request_user_input: bool,
     pub default_mode_request_user_input: bool,
@@ -216,6 +217,11 @@ impl ToolsConfig {
         let include_js_repl_tools_only =
             include_js_repl && features.enabled(Feature::JsReplToolsOnly);
         let include_collab_tools = features.enabled(Feature::Collab);
+        let include_spawn_agent_tool = include_collab_tools
+            && !matches!(
+                session_source,
+                SessionSource::SubAgent(SubAgentSource::ThreadSpawn { .. })
+            );
         let include_multi_agent_v2 = features.enabled(Feature::MultiAgentV2);
         let include_agent_jobs = features.enabled(Feature::SpawnCsv);
         let include_request_user_input = !matches!(session_source, SessionSource::SubAgent(_));
@@ -301,6 +307,7 @@ impl ToolsConfig {
             js_repl_tools_only: include_js_repl_tools_only,
             can_request_original_image_detail: include_original_image_detail,
             collab_tools: include_collab_tools,
+            spawn_agent_tool: include_spawn_agent_tool,
             multi_agent_v2: include_multi_agent_v2,
             request_user_input: include_request_user_input,
             default_mode_request_user_input: include_default_mode_request_user_input,
@@ -799,17 +806,19 @@ pub(crate) fn build_specs_with_discoverable_tools(
             Arc::new(WaitForAgentProgressHandler),
         );
         if config.multi_agent_v2 {
-            push_tool_spec(
-                &mut builder,
-                create_spawn_agent_tool_v2(SpawnAgentToolOptions {
-                    available_models: &config.available_models,
-                    agent_type_description: crate::agent::role::spawn_tool_spec::build(
-                        &config.agent_roles,
-                    ),
-                }),
-                /*supports_parallel_tool_calls*/ false,
-                config.code_mode_enabled,
-            );
+            if config.spawn_agent_tool {
+                push_tool_spec(
+                    &mut builder,
+                    create_spawn_agent_tool_v2(SpawnAgentToolOptions {
+                        available_models: &config.available_models,
+                        agent_type_description: crate::agent::role::spawn_tool_spec::build(
+                            &config.agent_roles,
+                        ),
+                    }),
+                    /*supports_parallel_tool_calls*/ false,
+                    config.code_mode_enabled,
+                );
+            }
             push_tool_spec(
                 &mut builder,
                 create_send_message_tool(),
@@ -844,24 +853,28 @@ pub(crate) fn build_specs_with_discoverable_tools(
                 /*supports_parallel_tool_calls*/ false,
                 config.code_mode_enabled,
             );
-            builder.register_handler("spawn_agent", Arc::new(SpawnAgentHandlerV2));
+            if config.spawn_agent_tool {
+                builder.register_handler("spawn_agent", Arc::new(SpawnAgentHandlerV2));
+            }
             builder.register_handler("send_message", Arc::new(SendMessageHandlerV2));
             builder.register_handler("assign_task", Arc::new(AssignTaskHandlerV2));
             builder.register_handler("wait_agent", Arc::new(WaitAgentHandlerV2));
             builder.register_handler("close_agent", Arc::new(CloseAgentHandlerV2));
             builder.register_handler("list_agents", Arc::new(ListAgentsHandlerV2));
         } else {
-            push_tool_spec(
-                &mut builder,
-                create_spawn_agent_tool_v1(SpawnAgentToolOptions {
-                    available_models: &config.available_models,
-                    agent_type_description: crate::agent::role::spawn_tool_spec::build(
-                        &config.agent_roles,
-                    ),
-                }),
-                /*supports_parallel_tool_calls*/ false,
-                config.code_mode_enabled,
-            );
+            if config.spawn_agent_tool {
+                push_tool_spec(
+                    &mut builder,
+                    create_spawn_agent_tool_v1(SpawnAgentToolOptions {
+                        available_models: &config.available_models,
+                        agent_type_description: crate::agent::role::spawn_tool_spec::build(
+                            &config.agent_roles,
+                        ),
+                    }),
+                    /*supports_parallel_tool_calls*/ false,
+                    config.code_mode_enabled,
+                );
+            }
             push_tool_spec(
                 &mut builder,
                 create_send_input_tool_v1(),
@@ -891,7 +904,9 @@ pub(crate) fn build_specs_with_discoverable_tools(
                 /*supports_parallel_tool_calls*/ false,
                 config.code_mode_enabled,
             );
-            builder.register_handler("spawn_agent", Arc::new(SpawnAgentHandler));
+            if config.spawn_agent_tool {
+                builder.register_handler("spawn_agent", Arc::new(SpawnAgentHandler));
+            }
             builder.register_handler("send_input", Arc::new(SendInputHandler));
             builder.register_handler("wait_agent", Arc::new(WaitAgentHandler));
             builder.register_handler("close_agent", Arc::new(CloseAgentHandler));

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -6,6 +6,7 @@ use crate::shell::ShellType;
 use crate::tools::ToolRouter;
 use crate::tools::router::ToolRouterParams;
 use codex_app_server_protocol::AppInfo;
+use codex_protocol::ThreadId;
 use codex_protocol::models::VIEW_IMAGE_TOOL_NAME;
 use codex_protocol::openai_models::InputModality;
 use codex_protocol::openai_models::ModelInfo;
@@ -834,6 +835,94 @@ fn test_build_specs_agent_job_worker_tools_enabled() {
             "report_agent_job_result",
         ],
     );
+    assert_lacks_tool_name(&tools, "request_user_input");
+}
+
+#[test]
+fn test_build_specs_thread_spawn_subagent_hides_spawn_agent_tool_v1() {
+    let config = test_config();
+    let model_info = ModelsManager::construct_model_info_offline_for_tests("gpt-5-codex", &config);
+    let features = Features::with_defaults();
+    let available_models = Vec::new();
+    let tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &features,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+            parent_thread_id: ThreadId::new(),
+            depth: 1,
+            agent_path: None,
+            agent_nickname: None,
+            agent_role: None,
+        }),
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    });
+    let (tools, _) = build_specs(
+        &tools_config,
+        /*mcp_tools*/ None,
+        /*app_tools*/ None,
+        &[],
+    )
+    .build();
+    assert_contains_tool_names(
+        &tools,
+        &[
+            "inspect_agent_progress",
+            "wait_for_agent_progress",
+            "send_input",
+            "resume_agent",
+            "wait_agent",
+            "close_agent",
+        ],
+    );
+    assert_lacks_tool_name(&tools, "spawn_agent");
+    assert_lacks_tool_name(&tools, "request_user_input");
+}
+
+#[test]
+fn test_build_specs_thread_spawn_subagent_hides_spawn_agent_tool_v2() {
+    let config = test_config();
+    let model_info = ModelsManager::construct_model_info_offline_for_tests("gpt-5-codex", &config);
+    let mut features = Features::with_defaults();
+    features.enable(Feature::MultiAgentV2);
+    let available_models = Vec::new();
+    let tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &features,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+            parent_thread_id: ThreadId::new(),
+            depth: 1,
+            agent_path: None,
+            agent_nickname: None,
+            agent_role: None,
+        }),
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    });
+    let (tools, _) = build_specs(
+        &tools_config,
+        /*mcp_tools*/ None,
+        /*app_tools*/ None,
+        &[],
+    )
+    .build();
+    assert_contains_tool_names(
+        &tools,
+        &[
+            "inspect_agent_progress",
+            "wait_for_agent_progress",
+            "send_message",
+            "assign_task",
+            "wait_agent",
+            "close_agent",
+            "list_agents",
+        ],
+    );
+    assert_lacks_tool_name(&tools, "spawn_agent");
     assert_lacks_tool_name(&tools, "request_user_input");
 }
 

--- a/docs/custom-fork-module-inventory.md
+++ b/docs/custom-fork-module-inventory.md
@@ -5,8 +5,8 @@ must be revalidated when ingesting new upstream Codex releases.
 
 It complements:
 
-- [docs/fork-updates.md](/home/rose/work/codex/fork/docs/fork-updates.md)
-- [docs/local-builds.md](/home/rose/work/codex/fork/docs/local-builds.md)
+- [docs/fork-updates.md](fork-updates.md)
+- [docs/local-builds.md](local-builds.md)
 
 Those two docs explain the release-ingest workflow. This one explains what the
 fork actually adds on top of upstream.
@@ -25,7 +25,7 @@ release-merge artifact.
 ## How to use this during upstream ingest
 
 1. Rebase or merge the new upstream release into the fork using
-   [docs/fork-updates.md](/home/rose/work/codex/fork/docs/fork-updates.md).
+   [docs/fork-updates.md](fork-updates.md).
 2. Revisit each module listed here, in order.
 3. Resolve conflicts in the listed hot files first.
 4. Re-run the targeted tests for the affected bundle before doing a wider build.
@@ -67,22 +67,22 @@ release-merge artifact.
 
 ### Runtime hot files
 
-- [codex-rs/core/src/continuation_bridge.rs](/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge.rs)
-- [codex-rs/core/src/continuation_bridge/baton.rs](/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/baton.rs)
-- [codex-rs/core/src/continuation_bridge/rich_review.rs](/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/rich_review.rs)
-- [codex-rs/core/src/continuation_bridge/subagent_context.rs](/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/subagent_context.rs)
-- [codex-rs/core/src/compact.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact.rs)
-- [codex-rs/core/src/compact_remote.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs)
-- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
-- [codex-rs/core/src/config/mod.rs](/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs)
-- [codex-rs/core/src/agent/control.rs](/home/rose/work/codex/fork/codex-rs/core/src/agent/control.rs)
+- [codex-rs/core/src/continuation_bridge.rs](../codex-rs/core/src/continuation_bridge.rs)
+- [codex-rs/core/src/continuation_bridge/baton.rs](../codex-rs/core/src/continuation_bridge/baton.rs)
+- [codex-rs/core/src/continuation_bridge/rich_review.rs](../codex-rs/core/src/continuation_bridge/rich_review.rs)
+- [codex-rs/core/src/continuation_bridge/subagent_context.rs](../codex-rs/core/src/continuation_bridge/subagent_context.rs)
+- [codex-rs/core/src/compact.rs](../codex-rs/core/src/compact.rs)
+- [codex-rs/core/src/compact_remote.rs](../codex-rs/core/src/compact_remote.rs)
+- [codex-rs/core/src/codex.rs](../codex-rs/core/src/codex.rs)
+- [codex-rs/core/src/config/mod.rs](../codex-rs/core/src/config/mod.rs)
+- [codex-rs/core/src/agent/control.rs](../codex-rs/core/src/agent/control.rs)
 
 ### Templates and schema artifacts
 
-- [codex-rs/core/templates/continuation_bridge/variants/baton/prompt.md](/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/baton/prompt.md)
-- [codex-rs/core/templates/continuation_bridge/variants/baton/schema.json](/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/baton/schema.json)
-- [codex-rs/core/templates/continuation_bridge/variants/rich_review/prompt.md](/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/rich_review/prompt.md)
-- [codex-rs/core/templates/continuation_bridge/variants/rich_review/schema.json](/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/rich_review/schema.json)
+- [codex-rs/core/templates/continuation_bridge/variants/baton/prompt.md](../codex-rs/core/templates/continuation_bridge/variants/baton/prompt.md)
+- [codex-rs/core/templates/continuation_bridge/variants/baton/schema.json](../codex-rs/core/templates/continuation_bridge/variants/baton/schema.json)
+- [codex-rs/core/templates/continuation_bridge/variants/rich_review/prompt.md](../codex-rs/core/templates/continuation_bridge/variants/rich_review/prompt.md)
+- [codex-rs/core/templates/continuation_bridge/variants/rich_review/schema.json](../codex-rs/core/templates/continuation_bridge/variants/rich_review/schema.json)
 
 ### Config surface
 
@@ -127,11 +127,11 @@ release-merge artifact.
 
 ### Main files
 
-- [scripts/rebase-bolt-on-release.sh](/home/rose/work/codex/fork/scripts/rebase-bolt-on-release.sh)
-- [scripts/build-vscode-binary.sh](/home/rose/work/codex/fork/scripts/build-vscode-binary.sh)
-- [scripts/prune-build-artifacts.sh](/home/rose/work/codex/fork/scripts/prune-build-artifacts.sh)
-- [docs/fork-updates.md](/home/rose/work/codex/fork/docs/fork-updates.md)
-- [docs/local-builds.md](/home/rose/work/codex/fork/docs/local-builds.md)
+- [scripts/rebase-bolt-on-release.sh](../scripts/rebase-bolt-on-release.sh)
+- [scripts/build-vscode-binary.sh](../scripts/build-vscode-binary.sh)
+- [scripts/prune-build-artifacts.sh](../scripts/prune-build-artifacts.sh)
+- [docs/fork-updates.md](fork-updates.md)
+- [docs/local-builds.md](local-builds.md)
 
 ### Upstream conflict risk
 
@@ -163,13 +163,13 @@ release-merge artifact.
 
 ### Runtime hot files
 
-- [codex-rs/core/src/agent/progress.rs](/home/rose/work/codex/fork/codex-rs/core/src/agent/progress.rs)
-- [codex-rs/core/src/agent/control.rs](/home/rose/work/codex/fork/codex-rs/core/src/agent/control.rs)
-- [codex-rs/core/src/thread_manager.rs](/home/rose/work/codex/fork/codex-rs/core/src/thread_manager.rs)
-- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
-- [codex-rs/core/src/tools/handlers/agent_progress.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/handlers/agent_progress.rs)
-- [codex-rs/core/src/tools/spec.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs)
-- [codex-rs/tools/src/agent_progress_tool.rs](/home/rose/work/codex/fork/codex-rs/tools/src/agent_progress_tool.rs)
+- [codex-rs/core/src/agent/progress.rs](../codex-rs/core/src/agent/progress.rs)
+- [codex-rs/core/src/agent/control.rs](../codex-rs/core/src/agent/control.rs)
+- [codex-rs/core/src/thread_manager.rs](../codex-rs/core/src/thread_manager.rs)
+- [codex-rs/core/src/codex.rs](../codex-rs/core/src/codex.rs)
+- [codex-rs/core/src/tools/handlers/agent_progress.rs](../codex-rs/core/src/tools/handlers/agent_progress.rs)
+- [codex-rs/core/src/tools/spec.rs](../codex-rs/core/src/tools/spec.rs)
+- [codex-rs/tools/src/agent_progress_tool.rs](../codex-rs/tools/src/agent_progress_tool.rs)
 
 ### Upstream conflict risk
 
@@ -201,10 +201,10 @@ release-merge artifact.
 
 ### Runtime hot files
 
-- [codex-rs/core/src/governance/packets.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/packets.rs)
-- [codex-rs/core/src/governance/compiler.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/compiler.rs)
-- [codex-rs/core/src/governance/mod.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/mod.rs)
-- [codex-rs/core/src/config/mod.rs](/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs)
+- [codex-rs/core/src/governance/packets.rs](../codex-rs/core/src/governance/packets.rs)
+- [codex-rs/core/src/governance/compiler.rs](../codex-rs/core/src/governance/compiler.rs)
+- [codex-rs/core/src/governance/mod.rs](../codex-rs/core/src/governance/mod.rs)
+- [codex-rs/core/src/config/mod.rs](../codex-rs/core/src/config/mod.rs)
 
 ### Upstream conflict risk
 
@@ -234,9 +234,9 @@ release-merge artifact.
 
 ### Runtime hot files
 
-- [codex-rs/core/src/governance/transitions.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/transitions.rs)
-- [codex-rs/core/src/governance/diagnostics.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/diagnostics.rs)
-- [codex-rs/core/src/governance/compiler.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/compiler.rs)
+- [codex-rs/core/src/governance/transitions.rs](../codex-rs/core/src/governance/transitions.rs)
+- [codex-rs/core/src/governance/diagnostics.rs](../codex-rs/core/src/governance/diagnostics.rs)
+- [codex-rs/core/src/governance/compiler.rs](../codex-rs/core/src/governance/compiler.rs)
 
 ### Upstream conflict risk
 
@@ -265,12 +265,12 @@ release-merge artifact.
 
 ### Runtime hot files
 
-- [codex-rs/core/src/governance/thread_memory.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/thread_memory.rs)
-- [codex-rs/core/src/compact.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact.rs)
-- [codex-rs/core/src/compact_remote.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs)
-- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
-- [codex-rs/core/templates/thread_memory/prompt.md](/home/rose/work/codex/fork/codex-rs/core/templates/thread_memory/prompt.md)
-- [codex-rs/core/templates/thread_memory/schema.json](/home/rose/work/codex/fork/codex-rs/core/templates/thread_memory/schema.json)
+- [codex-rs/core/src/governance/thread_memory.rs](../codex-rs/core/src/governance/thread_memory.rs)
+- [codex-rs/core/src/compact.rs](../codex-rs/core/src/compact.rs)
+- [codex-rs/core/src/compact_remote.rs](../codex-rs/core/src/compact_remote.rs)
+- [codex-rs/core/src/codex.rs](../codex-rs/core/src/codex.rs)
+- [codex-rs/core/templates/thread_memory/prompt.md](../codex-rs/core/templates/thread_memory/prompt.md)
+- [codex-rs/core/templates/thread_memory/schema.json](../codex-rs/core/templates/thread_memory/schema.json)
 
 ### Upstream conflict risk
 
@@ -300,10 +300,10 @@ release-merge artifact.
 
 ### Runtime hot files
 
-- [codex-rs/core/src/governance/prompt_layers.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/prompt_layers.rs)
-- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
-- [codex-rs/core/src/context_manager/updates.rs](/home/rose/work/codex/fork/codex-rs/core/src/context_manager/updates.rs)
-- [codex-rs/core/templates/governance/prompt_layering.md](/home/rose/work/codex/fork/codex-rs/core/templates/governance/prompt_layering.md)
+- [codex-rs/core/src/governance/prompt_layers.rs](../codex-rs/core/src/governance/prompt_layers.rs)
+- [codex-rs/core/src/codex.rs](../codex-rs/core/src/codex.rs)
+- [codex-rs/core/src/context_manager/updates.rs](../codex-rs/core/src/context_manager/updates.rs)
+- [codex-rs/core/templates/governance/prompt_layering.md](../codex-rs/core/templates/governance/prompt_layering.md)
 
 ### Upstream conflict risk
 
@@ -333,9 +333,9 @@ release-merge artifact.
 
 ### Runtime hot files
 
-- [codex-rs/core/src/compact.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact.rs)
-- [codex-rs/core/src/compact_remote.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs)
-- [codex-rs/core/src/compact_tests.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_tests.rs)
+- [codex-rs/core/src/compact.rs](../codex-rs/core/src/compact.rs)
+- [codex-rs/core/src/compact_remote.rs](../codex-rs/core/src/compact_remote.rs)
+- [codex-rs/core/src/compact_tests.rs](../codex-rs/core/src/compact_tests.rs)
 
 ### Upstream conflict risk
 
@@ -366,8 +366,8 @@ fork-owned surface once merged to `origin/main`.
 
 ### Runtime hot files
 
-- [codex-rs/core/src/tools/spec.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs)
-- [codex-rs/core/src/tools/spec_tests.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/spec_tests.rs)
+- [codex-rs/core/src/tools/spec.rs](../codex-rs/core/src/tools/spec.rs)
+- [codex-rs/core/src/tools/spec_tests.rs](../codex-rs/core/src/tools/spec_tests.rs)
 
 ### Upstream conflict risk
 
@@ -384,14 +384,14 @@ fork-owned surface once merged to `origin/main`.
 
 These are the files most likely to conflict again on future upstream ingests:
 
-- [codex-rs/core/src/compact.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact.rs)
-- [codex-rs/core/src/compact_remote.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs)
-- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
-- [codex-rs/core/src/config/mod.rs](/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs)
-- [codex-rs/core/config.schema.json](/home/rose/work/codex/fork/codex-rs/core/config.schema.json)
-- [codex-rs/core/src/tools/spec.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs)
-- [codex-rs/core/src/agent/control.rs](/home/rose/work/codex/fork/codex-rs/core/src/agent/control.rs)
-- [codex-rs/core/src/context_manager/updates.rs](/home/rose/work/codex/fork/codex-rs/core/src/context_manager/updates.rs)
+- [codex-rs/core/src/compact.rs](../codex-rs/core/src/compact.rs)
+- [codex-rs/core/src/compact_remote.rs](../codex-rs/core/src/compact_remote.rs)
+- [codex-rs/core/src/codex.rs](../codex-rs/core/src/codex.rs)
+- [codex-rs/core/src/config/mod.rs](../codex-rs/core/src/config/mod.rs)
+- [codex-rs/core/config.schema.json](../codex-rs/core/config.schema.json)
+- [codex-rs/core/src/tools/spec.rs](../codex-rs/core/src/tools/spec.rs)
+- [codex-rs/core/src/agent/control.rs](../codex-rs/core/src/agent/control.rs)
+- [codex-rs/core/src/context_manager/updates.rs](../codex-rs/core/src/context_manager/updates.rs)
 
 ## Minimal post-ingest checklist
 

--- a/docs/custom-fork-module-inventory.md
+++ b/docs/custom-fork-module-inventory.md
@@ -1,0 +1,424 @@
+# Custom fork module inventory
+
+This document is the maintainer-facing map of the fork-owned surface area that
+must be revalidated when ingesting new upstream Codex releases.
+
+It complements:
+
+- [docs/fork-updates.md](/home/rose/work/codex/fork/docs/fork-updates.md)
+- [docs/local-builds.md](/home/rose/work/codex/fork/docs/local-builds.md)
+
+Those two docs explain the release-ingest workflow. This one explains what the
+fork actually adds on top of upstream.
+
+## Scope
+
+The inventory below is derived from the fork-only commit ranges:
+
+- merged fork surface: `upstream/main..origin/main`
+- branch-local additions, when present: `origin/main..HEAD`
+
+It intentionally focuses on fork-owned modules and their hot files. It does not
+attempt to restate every touched snapshot, lockfile refresh, or upstream
+release-merge artifact.
+
+## How to use this during upstream ingest
+
+1. Rebase or merge the new upstream release into the fork using
+   [docs/fork-updates.md](/home/rose/work/codex/fork/docs/fork-updates.md).
+2. Revisit each module listed here, in order.
+3. Resolve conflicts in the listed hot files first.
+4. Re-run the targeted tests for the affected bundle before doing a wider build.
+5. Update this document if a custom bundle is merged, removed, or replaced.
+
+## Bundle summary
+
+| Bundle | Status | Commits | Main seams |
+| --- | --- | --- | --- |
+| Continuation bridge | merged on `origin/main` | `c96b7f9e5a`, `afac096039`, `ab623fa1d1`, `1088d14864` | `compact.rs`, `compact_remote.rs`, `continuation_bridge.rs`, `config/mod.rs`, templates |
+| Update/build workflow | merged on `origin/main` | `bcd9716227`, `a3aefcd26a`, `532ff58d7d`, `909f9df193` | `scripts/rebase-bolt-on-release.sh`, `scripts/build-vscode-binary.sh`, `scripts/prune-build-artifacts.sh`, docs |
+| E-witness live sub-agent progress | merged on `origin/main` | `bf5705f1b4` | `agent/progress.rs`, `agent/control.rs`, `tools/spec.rs`, tool handlers/specs |
+| strict-v1 p1 packets/compiler | merged on `origin/main` | `4c24a10b79`, `933e19a1e1` | `governance/packets.rs`, `governance/compiler.rs`, `config/mod.rs` |
+| strict-v1 p2 transitions/diagnostics | merged on `origin/main` | `b1841b1abe`, `0b54dfec38` | `governance/transitions.rs`, `governance/diagnostics.rs` |
+| strict-v1 p3 thread memory | merged on `origin/main` | `a611d96b36`, `62adb98ead` | `governance/thread_memory.rs`, `compact.rs`, `compact_remote.rs`, templates |
+| strict-v1 p4 prompt layering | merged on `origin/main` | `6f53f9c9de`, `c287ba8676` | `governance/prompt_layers.rs`, `codex.rs`, `context_manager/updates.rs` |
+| strict-v1 p5 fail-closed compaction window | merged on `origin/main` | `e42a21fdbf`, `39232dce39` | `compact.rs`, `compact_remote.rs`, `compact_tests.rs` |
+| Thread-spawn sub-agent tool containment | branch-local on `HEAD` | current branch commit(s) | `tools/spec.rs`, `tools/spec_tests.rs` |
+
+## 1. Continuation bridge
+
+### Commits
+
+- `c96b7f9e5a` Add continuation bridge compaction handoff
+- `afac096039` Refine continuation bridge handoff
+- `ab623fa1d1` Refine continuation bridge variants and local build workflow
+- `1088d14864` Restore vanilla subagent environment context path
+
+### What it adds
+
+- A pre-compaction structured handoff artifact inserted back into replacement
+  history after compaction.
+- Variant support:
+  - `baton`
+  - `rich_review`
+- Optional dedicated model and reasoning overrides for bridge generation.
+- Optional prompt override for experimentation without rebuilding templates.
+- Coarse sub-agent carryover block for continuity across compaction.
+
+### Runtime hot files
+
+- [codex-rs/core/src/continuation_bridge.rs](/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge.rs)
+- [codex-rs/core/src/continuation_bridge/baton.rs](/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/baton.rs)
+- [codex-rs/core/src/continuation_bridge/rich_review.rs](/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/rich_review.rs)
+- [codex-rs/core/src/continuation_bridge/subagent_context.rs](/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/subagent_context.rs)
+- [codex-rs/core/src/compact.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact.rs)
+- [codex-rs/core/src/compact_remote.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs)
+- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
+- [codex-rs/core/src/config/mod.rs](/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs)
+- [codex-rs/core/src/agent/control.rs](/home/rose/work/codex/fork/codex-rs/core/src/agent/control.rs)
+
+### Templates and schema artifacts
+
+- [codex-rs/core/templates/continuation_bridge/variants/baton/prompt.md](/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/baton/prompt.md)
+- [codex-rs/core/templates/continuation_bridge/variants/baton/schema.json](/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/baton/schema.json)
+- [codex-rs/core/templates/continuation_bridge/variants/rich_review/prompt.md](/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/rich_review/prompt.md)
+- [codex-rs/core/templates/continuation_bridge/variants/rich_review/schema.json](/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/rich_review/schema.json)
+
+### Config surface
+
+- `continuation_bridge_prompt`
+- `continuation_bridge_prompt_file`
+- `continuation_bridge_variant`
+- `continuation_bridge_model`
+- `continuation_bridge_reasoning_effort`
+
+### Upstream conflict risk
+
+- High in compaction codepaths and turn-context plumbing.
+- Medium in config parsing/schema whenever upstream adds config fields or
+  refactors `Config`.
+- Medium in agent-control code when sub-agent metadata flow changes.
+
+### Revalidation focus after ingest
+
+- Manual compaction path still injects `<continuation_bridge ...>` after
+  compaction.
+- Remote compaction path still injects `<continuation_bridge ...>` after
+  `/responses/compact`.
+- Variant selection, prompt override, and bridge-model override still resolve
+  correctly.
+
+## 2. Update/build workflow helpers
+
+### Commits
+
+- `bcd9716227` Add bolt-on release rebase helper
+- `a3aefcd26a` Refresh lockfile versions during release rebases
+- `532ff58d7d` Refresh 0.115.0 lockfile and compaction snapshots
+- `909f9df193` Sync lockfile and remove stale custom_prompts export
+
+### What it adds
+
+- Release-ingest helper script for rebasing the fork patch stack onto a fresh
+  upstream release tag.
+- Stable local build helpers for the VS Code binary path.
+- Artifact pruning helper tuned for this fork’s Rust build workflow.
+- Maintainer docs for the update/build loop.
+
+### Main files
+
+- [scripts/rebase-bolt-on-release.sh](/home/rose/work/codex/fork/scripts/rebase-bolt-on-release.sh)
+- [scripts/build-vscode-binary.sh](/home/rose/work/codex/fork/scripts/build-vscode-binary.sh)
+- [scripts/prune-build-artifacts.sh](/home/rose/work/codex/fork/scripts/prune-build-artifacts.sh)
+- [docs/fork-updates.md](/home/rose/work/codex/fork/docs/fork-updates.md)
+- [docs/local-builds.md](/home/rose/work/codex/fork/docs/local-builds.md)
+
+### Upstream conflict risk
+
+- Low at runtime.
+- Medium whenever upstream changes workspace layout, package names, or release
+  build commands.
+
+### Revalidation focus after ingest
+
+- Rebase helper still identifies the correct `rust-v*` base tag.
+- VS Code binary script still copies the correct executable to the stable
+  wrapper path.
+- Prune script still matches the active build strategy.
+
+## 3. E-witness live sub-agent progress
+
+### Commit
+
+- `bf5705f1b4` Add E-witness agent progress inspection and wait tools
+
+### What it adds
+
+- Two collab tools:
+  - `inspect_agent_progress`
+  - `wait_for_agent_progress`
+- A live agent-progress reducer and registry for sub-agent execution phases.
+- Spawn-state and first-progress separation for launch-failure detection.
+- Material-progress wait primitive for orchestration loops.
+
+### Runtime hot files
+
+- [codex-rs/core/src/agent/progress.rs](/home/rose/work/codex/fork/codex-rs/core/src/agent/progress.rs)
+- [codex-rs/core/src/agent/control.rs](/home/rose/work/codex/fork/codex-rs/core/src/agent/control.rs)
+- [codex-rs/core/src/thread_manager.rs](/home/rose/work/codex/fork/codex-rs/core/src/thread_manager.rs)
+- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
+- [codex-rs/core/src/tools/handlers/agent_progress.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/handlers/agent_progress.rs)
+- [codex-rs/core/src/tools/spec.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs)
+- [codex-rs/tools/src/agent_progress_tool.rs](/home/rose/work/codex/fork/codex-rs/tools/src/agent_progress_tool.rs)
+
+### Upstream conflict risk
+
+- High in agent lifecycle event flow.
+- High in tool registration/spec wiring for collaboration mode.
+- Medium in thread-manager state ownership.
+
+### Revalidation focus after ingest
+
+- `inspect_agent_progress` still returns coherent snapshots.
+- `wait_for_agent_progress` still matches on phase/seq transitions.
+- Spawned children still emit progress events into the reducer.
+
+## 4. strict-v1 p1 packets/compiler scaffolding
+
+### Commits
+
+- `4c24a10b79` strict-v1 p1 packet scaffolding
+- `933e19a1e1` governance compiler: improve duplicate-layer diagnostics
+
+### What it adds
+
+- `GovernancePathVariant` modes:
+  - `off`
+  - `strict_v1_shadow`
+  - `strict_v1_enforce`
+- Typed packet/compiler scaffolding for constitutional prompting.
+- Projection/provenance-style compiler diagnostics for malformed layer inputs.
+
+### Runtime hot files
+
+- [codex-rs/core/src/governance/packets.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/packets.rs)
+- [codex-rs/core/src/governance/compiler.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/compiler.rs)
+- [codex-rs/core/src/governance/mod.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/mod.rs)
+- [codex-rs/core/src/config/mod.rs](/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs)
+
+### Upstream conflict risk
+
+- Medium in config plumbing.
+- Medium in any future upstream governance/prompt-layer abstraction.
+
+### Revalidation focus after ingest
+
+- `governance_path_variant` still parses from config/schema.
+- Compiler still rejects duplicate or malformed layers cleanly.
+
+## 5. strict-v1 p2 transition legality and diagnostics
+
+### Commits
+
+- `b1841b1abe` strict-v1 p2: add transition legality checks and diagnostics
+- `0b54dfec38` strict-v1 p2: tighten transition continuity checks
+
+### What it adds
+
+- Transition legality model for:
+  - spawn
+  - compact
+  - resume
+  - swap
+- Diagnostics taxonomy for governance-path validation failures.
+
+### Runtime hot files
+
+- [codex-rs/core/src/governance/transitions.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/transitions.rs)
+- [codex-rs/core/src/governance/diagnostics.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/diagnostics.rs)
+- [codex-rs/core/src/governance/compiler.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/compiler.rs)
+
+### Upstream conflict risk
+
+- Low to medium until the legality engine is wired more deeply into runtime
+  execution paths.
+- Medium if upstream introduces its own typed transition model.
+
+### Revalidation focus after ingest
+
+- Transition tests still pass.
+- Diagnostic classes remain stable and readable.
+
+## 6. strict-v1 p3 thread memory
+
+### Commits
+
+- `a611d96b36` Add strict-v1 thread memory compaction artifact
+- `62adb98ead` Address PR feedback on thread-memory compaction delta
+
+### What it adds
+
+- ODEU-thread-memory artifact generation during compaction.
+- Thread-memory templates and schema.
+- Reinjection of `<thread_memory ...>` into compacted replacement history when
+  strict governance mode is active.
+
+### Runtime hot files
+
+- [codex-rs/core/src/governance/thread_memory.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/thread_memory.rs)
+- [codex-rs/core/src/compact.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact.rs)
+- [codex-rs/core/src/compact_remote.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs)
+- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
+- [codex-rs/core/templates/thread_memory/prompt.md](/home/rose/work/codex/fork/codex-rs/core/templates/thread_memory/prompt.md)
+- [codex-rs/core/templates/thread_memory/schema.json](/home/rose/work/codex/fork/codex-rs/core/templates/thread_memory/schema.json)
+
+### Upstream conflict risk
+
+- High in compaction paths.
+- Medium in memory/state-db interfaces if upstream changes thread-memory or
+  memory-pollution handling.
+
+### Revalidation focus after ingest
+
+- Strict modes still inject `thread_memory`.
+- Previous memory is reused/updated rather than duplicated.
+- The artifact still coexists correctly with the continuation bridge.
+
+## 7. strict-v1 p4 prompt layering
+
+### Commits
+
+- `6f53f9c9de` strict-v1 p4: add governance prompt layering semantics
+- `c287ba8676` strict-v1 p4: fix governance layering update ordering and presence
+
+### What it adds
+
+- Constitutional/role/task/runtime prompt-layer synthesis.
+- Projection witness-like tagged prompt block inserted into live context.
+- Update-path propagation so the same layered prompt survives settings updates,
+  not just initial thread construction.
+
+### Runtime hot files
+
+- [codex-rs/core/src/governance/prompt_layers.rs](/home/rose/work/codex/fork/codex-rs/core/src/governance/prompt_layers.rs)
+- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
+- [codex-rs/core/src/context_manager/updates.rs](/home/rose/work/codex/fork/codex-rs/core/src/context_manager/updates.rs)
+- [codex-rs/core/templates/governance/prompt_layering.md](/home/rose/work/codex/fork/codex-rs/core/templates/governance/prompt_layering.md)
+
+### Upstream conflict risk
+
+- High in prompt construction and update ordering.
+- High in any future upstream changes to base/developer instruction injection.
+
+### Revalidation focus after ingest
+
+- `<governance_prompt_layers ...>` still appears at thread start.
+- The same block still appears after runtime settings/context updates.
+- Prompt-layer ordering still matches constitutional -> role -> task -> runtime.
+
+## 8. strict-v1 p5 fail-closed thread memory and raw-window trimming
+
+### Commits
+
+- `e42a21fdbf` Fail-closed governed thread memory and trim raw compaction history
+- `39232dce39` Emit local compact error event for fail-closed thread memory
+
+### What it adds
+
+- Fail-closed behavior for required `thread_memory` generation.
+- Explicit local compaction error event emission when required thread-memory
+  generation fails.
+- Trimmed raw retained conversation window so strict compaction keeps less
+  preserved verbatim history around the authoritative artifacts.
+
+### Runtime hot files
+
+- [codex-rs/core/src/compact.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact.rs)
+- [codex-rs/core/src/compact_remote.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs)
+- [codex-rs/core/src/compact_tests.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_tests.rs)
+
+### Upstream conflict risk
+
+- Very high in compaction paths because this bundle changes failure semantics,
+  not just additive artifacts.
+
+### Revalidation focus after ingest
+
+- Strict compaction fails loudly when required thread-memory generation fails.
+- Local compaction emits an explicit error event before aborting.
+- Raw retained history is reduced only when thread-memory is present.
+
+## 9. Thread-spawn sub-agent tool containment
+
+### Status
+
+This bundle is branch-local while this PR is open. It becomes part of the
+fork-owned surface once merged to `origin/main`.
+
+### What it adds
+
+- Hides `spawn_agent` from thread-spawned sub-agents so they keep collab
+  observability/control tools without being able to recursively delegate.
+- Preserves the rest of the sub-agent collaboration surface:
+  - `inspect_agent_progress`
+  - `wait_for_agent_progress`
+  - wait/send/close agent tools appropriate to the v1/v2 collaboration mode
+
+### Runtime hot files
+
+- [codex-rs/core/src/tools/spec.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs)
+- [codex-rs/core/src/tools/spec_tests.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/spec_tests.rs)
+
+### Upstream conflict risk
+
+- Medium to high in tool-surface construction for collaboration mode.
+- Medium if upstream changes how thread-spawn session sources are modeled.
+
+### Revalidation focus after ingest
+
+- Thread-spawned children still get E-witness tools.
+- Thread-spawned children do not get `spawn_agent`.
+- Root/session agents still expose `spawn_agent` normally.
+
+## Hot files across multiple bundles
+
+These are the files most likely to conflict again on future upstream ingests:
+
+- [codex-rs/core/src/compact.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact.rs)
+- [codex-rs/core/src/compact_remote.rs](/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs)
+- [codex-rs/core/src/codex.rs](/home/rose/work/codex/fork/codex-rs/core/src/codex.rs)
+- [codex-rs/core/src/config/mod.rs](/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs)
+- [codex-rs/core/config.schema.json](/home/rose/work/codex/fork/codex-rs/core/config.schema.json)
+- [codex-rs/core/src/tools/spec.rs](/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs)
+- [codex-rs/core/src/agent/control.rs](/home/rose/work/codex/fork/codex-rs/core/src/agent/control.rs)
+- [codex-rs/core/src/context_manager/updates.rs](/home/rose/work/codex/fork/codex-rs/core/src/context_manager/updates.rs)
+
+## Minimal post-ingest checklist
+
+After ingesting a new upstream release, verify at minimum:
+
+1. Continuation bridge still generates and reinjects correctly for both local
+   and remote compaction.
+2. E-witness tools still appear in collab mode and report live sub-agent
+   progress coherently.
+3. `strict_v1_shadow` still injects both governance prompt layers and
+   thread-memory artifacts.
+4. Fail-closed compaction still aborts correctly and surfaces a local error
+   event.
+5. Thread-spawned sub-agents still keep observability tools but not
+   `spawn_agent`.
+6. The local helper scripts in `scripts/` still match the actual build/update
+   workflow of the workspace.
+
+## Commands used to refresh this inventory
+
+```sh
+git log --reverse --oneline upstream/main..origin/main
+git log --reverse --oneline origin/main..HEAD
+```
+
+For a bundle-level file list:
+
+```sh
+git show --format= --name-only <commit>
+```

--- a/docs/custom-governance-path-build-guide.md
+++ b/docs/custom-governance-path-build-guide.md
@@ -1,0 +1,313 @@
+# Custom Governance Path Build Guide (Code-Grounded)
+
+This document describes what is implemented in this fork today, based on the current code in `codex-rs`.
+
+It is intentionally operational and code-grounded, not conceptual.
+
+## Scope
+
+The custom lane currently spans four concrete areas:
+
+1. Continuation bridge artifacts injected before compaction.
+2. ODEU thread-memory artifacts injected before compaction.
+3. Strict-v1 governance packet/layering scaffolding.
+4. E-witness live progress inspection/wait tools for sub-agents.
+5. Fail-closed strict compaction behavior when required thread-memory
+   generation fails.
+6. Thread-spawn sub-agent tool containment so child lanes keep observability
+   but do not recursively spawn more agents.
+
+## 1) Continuation Bridge (Implemented)
+
+### What it does
+
+Before local or remote compaction, Codex can generate a structured continuation handoff as a tagged `developer` message:
+
+- `<continuation_bridge schema="..."> ... </continuation_bridge>`
+
+This handoff is inserted into `replacement_history` so the successor instance receives a compact, structured baton.
+
+### Core implementation
+
+- Generator and parser:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge.rs`
+- Bridge variants:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/baton.rs`
+  - `/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/rich_review.rs`
+- Prompt/schema artifacts:
+  - `/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/baton/prompt.md`
+  - `/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/baton/schema.json`
+  - `/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/rich_review/prompt.md`
+  - `/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/rich_review/schema.json`
+
+### Variants
+
+- `continuation_bridge_baton_v1` (lean baton pass).
+- `continuation_bridge_v2` (richer review-oriented handoff, with legacy `continuation_bridge_v1` accepted by parser).
+
+### Model control for bridge generation
+
+Bridge generation can use a dedicated model/reasoning effort, with fallback to resident model when unavailable/unsupported.
+
+- Defaults in code:
+  - model: `gpt-5-codex-mini`
+  - reasoning effort: `high`
+- Config fields:
+  - `continuation_bridge_variant`
+  - `continuation_bridge_model`
+  - `continuation_bridge_reasoning_effort`
+  - `continuation_bridge_prompt` and `continuation_bridge_prompt_file`
+
+See:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs`
+- `/home/rose/work/codex/fork/codex-rs/core/src/codex.rs` (`continuation_bridge_prompt`, `continuation_bridge_variant`)
+
+### Compaction integration
+
+Bridge generation is called in both compaction paths:
+
+- Local compaction:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/compact.rs`
+- Remote compaction:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs`
+
+In both paths, bridge items are treated as authoritative and inserted before summary/compaction marker in replacement history.
+
+## 2) ODEU Thread Memory (Implemented)
+
+### What it does
+
+When governance mode is enabled (`governance_path_variant != off`), compaction builds and injects a structured thread-memory artifact:
+
+- `<thread_memory schema="odeu_thread_memory_v1"> ... </thread_memory>`
+
+The updater treats the latest prior thread-memory artifact as canonical base and applies only delta from later source items.
+
+### Core implementation
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/governance/thread_memory.rs`
+- Prompt/schema artifacts:
+  - `/home/rose/work/codex/fork/codex-rs/core/templates/thread_memory/prompt.md`
+  - `/home/rose/work/codex/fork/codex-rs/core/templates/thread_memory/schema.json`
+
+### Update mechanics currently implemented
+
+- Uses latest tagged `<thread_memory ...>` message as previous canonical memory.
+- Filters source items to avoid feeding prior thread-memory/continuation-bridge artifacts back into delta input.
+- Caps source items to `MAX_SOURCE_ITEMS = 160`.
+- Uses output schema enforcement for structured JSON-only output.
+
+### Compaction integration
+
+Thread-memory generation is invoked in:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/compact.rs`
+- `/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs`
+
+Gated by `governance_path_variant`:
+
+- `off`: no thread-memory artifact.
+- `strict_v1_shadow` / `strict_v1_enforce`: thread-memory artifact enabled.
+
+### Fail-closed behavior and raw-window trimming
+
+Strict thread-memory compaction now fails closed when required memory generation
+returns empty output or errors before local/remote compaction completes.
+
+Implemented in:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/compact.rs`
+- `/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs`
+
+Current behavior:
+
+- local compaction emits an explicit error event before aborting when required
+  thread-memory generation fails
+- remote compaction aborts rather than silently dropping required memory
+- strict compaction trims preserved raw conversation more aggressively once the
+  authoritative `thread_memory` artifact is present
+
+### Memory-mode contamination marker
+
+If `memories.no_memories_if_mcp_or_web_search = true`, MCP tool calls and web-search calls mark thread memory mode as polluted in state DB:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/mcp_tool_call.rs`
+- `/home/rose/work/codex/fork/codex-rs/core/src/stream_events_utils.rs`
+- Bridge re-export:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/state_db_bridge.rs`
+
+## 3) Strict-v1 Governance Path (Implemented as Scaffolding + Prompt Layering)
+
+### Config mode
+
+- `governance_path_variant` enum:
+  - `off`
+  - `strict_v1_shadow`
+  - `strict_v1_enforce`
+
+Defined in:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs`
+
+### Typed packet model
+
+Implemented packet types and force typing:
+
+- `NormativeForce`: `hard | default | advisory | factual`
+- Layers:
+  - constitution
+  - role
+  - task_charter
+  - task_residual
+  - runtime_fact_store
+  - adapter_overlay
+
+Defined in:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/governance/packets.rs`
+
+### Compiler + provenance witness
+
+Implemented:
+
+- packet compilation with duplicate-layer checks and constitution requirement in strict modes.
+- projection witness with accepted/rejected/ambiguity records.
+
+Defined in:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/governance/compiler.rs`
+
+### Diagnostics taxonomy + transition legality rules
+
+Implemented:
+
+- diagnostic severities, codes, violation kinds.
+- legality checker for transitions:
+  - `spawn`
+  - `compact`
+  - `resume`
+  - `swap`
+- mode behavior:
+  - `off`: allow
+  - `strict_v1_shadow`: allow with diagnostics
+  - `strict_v1_enforce`: block on errors
+
+Defined in:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/governance/diagnostics.rs`
+- `/home/rose/work/codex/fork/codex-rs/core/src/governance/transitions.rs`
+
+Current status: these transition checks are implemented and tested, but not yet wired as a runtime gate in the main execution path.
+
+### Prompt layering contract (active in runtime)
+
+A `<governance_prompt_layers ...>` tagged payload is generated and injected into developer context for strict modes.
+
+Defined in:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/governance/prompt_layers.rs`
+- contract text:
+  - `/home/rose/work/codex/fork/codex-rs/core/templates/governance/prompt_layering.md`
+
+Wired in:
+
+- initial context building:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/codex.rs`
+- settings update building:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/context_manager/updates.rs`
+
+Recent fix included:
+
+- Keep `<model_switch>` first when present; insert governance section after it.
+- Build settings-update governance payload from full active role/task/runtime sections (not only diff fragments).
+
+## 4) E-Witness Lane for Sub-Agents (Implemented)
+
+### What it does
+
+Adds live, normalized sub-agent progress observability without exposing raw hidden reasoning.
+
+Two tools are exposed (when collaboration tools are enabled):
+
+- `inspect_agent_progress`
+- `wait_for_agent_progress`
+
+### Core implementation
+
+- progress reducer/registry:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/agent/progress.rs`
+- control-plane API:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/agent/control.rs`
+- tool handlers:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/tools/handlers/agent_progress.rs`
+- tool specs:
+  - `/home/rose/work/codex/fork/codex-rs/tools/src/agent_progress_tool.rs`
+  - `/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs`
+
+### Thread-spawn containment rule
+
+Thread-spawned sub-agents keep the E-witness/control-plane tools needed for
+supervision, but do not receive `spawn_agent`.
+
+Implemented in:
+
+- `/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs`
+- tests:
+  - `/home/rose/work/codex/fork/codex-rs/core/src/tools/spec_tests.rs`
+
+Current effect:
+
+- thread-spawned children still expose:
+  - `inspect_agent_progress`
+  - `wait_for_agent_progress`
+  - wait/send/close tools appropriate to their v1/v2 collaboration mode
+- thread-spawned children do not expose `spawn_agent`
+- this is a containment measure for recursive delegation, not a full solution
+  to semantic role contamination
+
+### Snapshot fields implemented
+
+`inspect_agent_progress` and `wait_for_agent_progress` report normalized fields including:
+
+- `phase`
+- `blocked_on`
+- `active_work`
+- `recent_updates`
+- `latest_visible_message`
+- `final_message`
+- `error_message`
+- `ever_entered_turn`
+- `ever_reported_progress`
+- `seq` (material progress sequence)
+- `stalled`
+
+### Wait semantics implemented
+
+`wait_for_agent_progress` can wait on:
+
+- `seq` advancing beyond `since_seq`
+- phase match (`until_phases`)
+- timeout (with bounded/clamped timeout range)
+
+## 5) Known Limitations / Current Boundary
+
+1. Strict-v1 transition legality is implemented but currently not yet enforced inline in runtime transitions.
+2. Thread-memory and continuation-bridge are additive artifacts around compaction; server `/responses/compact` remains canonical transcript compactor.
+3. Prompt-layering payload is an active guidance/diagnostic channel, not yet a hard execution planner.
+4. Thread-spawn `spawn_agent` suppression reduces recursive delegation blast radius, but it does not by itself solve inherited-role contamination in forked contexts.
+
+## 6) Minimal Config Example
+
+```toml
+# Enable strict governance lane
+governance_path_variant = "strict_v1_shadow"
+
+# Continuation bridge controls
+continuation_bridge_variant = "baton" # or "rich_review"
+continuation_bridge_model = "gpt-5-codex-mini"
+continuation_bridge_reasoning_effort = "high"
+
+# Optional custom bridge prompt
+# continuation_bridge_prompt_file = "/absolute/path/to/prompt.txt"
+```

--- a/docs/custom-governance-path-build-guide.md
+++ b/docs/custom-governance-path-build-guide.md
@@ -30,15 +30,15 @@ This handoff is inserted into `replacement_history` so the successor instance re
 ### Core implementation
 
 - Generator and parser:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge.rs`
+  - `codex-rs/core/src/continuation_bridge.rs`
 - Bridge variants:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/baton.rs`
-  - `/home/rose/work/codex/fork/codex-rs/core/src/continuation_bridge/rich_review.rs`
+  - `codex-rs/core/src/continuation_bridge/baton.rs`
+  - `codex-rs/core/src/continuation_bridge/rich_review.rs`
 - Prompt/schema artifacts:
-  - `/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/baton/prompt.md`
-  - `/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/baton/schema.json`
-  - `/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/rich_review/prompt.md`
-  - `/home/rose/work/codex/fork/codex-rs/core/templates/continuation_bridge/variants/rich_review/schema.json`
+  - `codex-rs/core/templates/continuation_bridge/variants/baton/prompt.md`
+  - `codex-rs/core/templates/continuation_bridge/variants/baton/schema.json`
+  - `codex-rs/core/templates/continuation_bridge/variants/rich_review/prompt.md`
+  - `codex-rs/core/templates/continuation_bridge/variants/rich_review/schema.json`
 
 ### Variants
 
@@ -60,17 +60,17 @@ Bridge generation can use a dedicated model/reasoning effort, with fallback to r
 
 See:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs`
-- `/home/rose/work/codex/fork/codex-rs/core/src/codex.rs` (`continuation_bridge_prompt`, `continuation_bridge_variant`)
+- `codex-rs/core/src/config/mod.rs`
+- `codex-rs/core/src/codex.rs` (`continuation_bridge_prompt`, `continuation_bridge_variant`)
 
 ### Compaction integration
 
 Bridge generation is called in both compaction paths:
 
 - Local compaction:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/compact.rs`
+  - `codex-rs/core/src/compact.rs`
 - Remote compaction:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs`
+  - `codex-rs/core/src/compact_remote.rs`
 
 In both paths, bridge items are treated as authoritative and inserted before summary/compaction marker in replacement history.
 
@@ -86,10 +86,10 @@ The updater treats the latest prior thread-memory artifact as canonical base and
 
 ### Core implementation
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/governance/thread_memory.rs`
+- `codex-rs/core/src/governance/thread_memory.rs`
 - Prompt/schema artifacts:
-  - `/home/rose/work/codex/fork/codex-rs/core/templates/thread_memory/prompt.md`
-  - `/home/rose/work/codex/fork/codex-rs/core/templates/thread_memory/schema.json`
+  - `codex-rs/core/templates/thread_memory/prompt.md`
+  - `codex-rs/core/templates/thread_memory/schema.json`
 
 ### Update mechanics currently implemented
 
@@ -102,8 +102,8 @@ The updater treats the latest prior thread-memory artifact as canonical base and
 
 Thread-memory generation is invoked in:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/compact.rs`
-- `/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs`
+- `codex-rs/core/src/compact.rs`
+- `codex-rs/core/src/compact_remote.rs`
 
 Gated by `governance_path_variant`:
 
@@ -117,8 +117,8 @@ returns empty output or errors before local/remote compaction completes.
 
 Implemented in:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/compact.rs`
-- `/home/rose/work/codex/fork/codex-rs/core/src/compact_remote.rs`
+- `codex-rs/core/src/compact.rs`
+- `codex-rs/core/src/compact_remote.rs`
 
 Current behavior:
 
@@ -132,10 +132,10 @@ Current behavior:
 
 If `memories.no_memories_if_mcp_or_web_search = true`, MCP tool calls and web-search calls mark thread memory mode as polluted in state DB:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/mcp_tool_call.rs`
-- `/home/rose/work/codex/fork/codex-rs/core/src/stream_events_utils.rs`
+- `codex-rs/core/src/mcp_tool_call.rs`
+- `codex-rs/core/src/stream_events_utils.rs`
 - Bridge re-export:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/state_db_bridge.rs`
+  - `codex-rs/core/src/state_db_bridge.rs`
 
 ## 3) Strict-v1 Governance Path (Implemented as Scaffolding + Prompt Layering)
 
@@ -148,7 +148,7 @@ If `memories.no_memories_if_mcp_or_web_search = true`, MCP tool calls and web-se
 
 Defined in:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/config/mod.rs`
+- `codex-rs/core/src/config/mod.rs`
 
 ### Typed packet model
 
@@ -165,7 +165,7 @@ Implemented packet types and force typing:
 
 Defined in:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/governance/packets.rs`
+- `codex-rs/core/src/governance/packets.rs`
 
 ### Compiler + provenance witness
 
@@ -176,7 +176,7 @@ Implemented:
 
 Defined in:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/governance/compiler.rs`
+- `codex-rs/core/src/governance/compiler.rs`
 
 ### Diagnostics taxonomy + transition legality rules
 
@@ -195,8 +195,8 @@ Implemented:
 
 Defined in:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/governance/diagnostics.rs`
-- `/home/rose/work/codex/fork/codex-rs/core/src/governance/transitions.rs`
+- `codex-rs/core/src/governance/diagnostics.rs`
+- `codex-rs/core/src/governance/transitions.rs`
 
 Current status: these transition checks are implemented and tested, but not yet wired as a runtime gate in the main execution path.
 
@@ -206,16 +206,16 @@ A `<governance_prompt_layers ...>` tagged payload is generated and injected into
 
 Defined in:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/governance/prompt_layers.rs`
+- `codex-rs/core/src/governance/prompt_layers.rs`
 - contract text:
-  - `/home/rose/work/codex/fork/codex-rs/core/templates/governance/prompt_layering.md`
+  - `codex-rs/core/templates/governance/prompt_layering.md`
 
 Wired in:
 
 - initial context building:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/codex.rs`
+  - `codex-rs/core/src/codex.rs`
 - settings update building:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/context_manager/updates.rs`
+  - `codex-rs/core/src/context_manager/updates.rs`
 
 Recent fix included:
 
@@ -236,14 +236,14 @@ Two tools are exposed (when collaboration tools are enabled):
 ### Core implementation
 
 - progress reducer/registry:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/agent/progress.rs`
+  - `codex-rs/core/src/agent/progress.rs`
 - control-plane API:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/agent/control.rs`
+  - `codex-rs/core/src/agent/control.rs`
 - tool handlers:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/tools/handlers/agent_progress.rs`
+  - `codex-rs/core/src/tools/handlers/agent_progress.rs`
 - tool specs:
-  - `/home/rose/work/codex/fork/codex-rs/tools/src/agent_progress_tool.rs`
-  - `/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs`
+  - `codex-rs/tools/src/agent_progress_tool.rs`
+  - `codex-rs/core/src/tools/spec.rs`
 
 ### Thread-spawn containment rule
 
@@ -252,9 +252,9 @@ supervision, but do not receive `spawn_agent`.
 
 Implemented in:
 
-- `/home/rose/work/codex/fork/codex-rs/core/src/tools/spec.rs`
+- `codex-rs/core/src/tools/spec.rs`
 - tests:
-  - `/home/rose/work/codex/fork/codex-rs/core/src/tools/spec_tests.rs`
+  - `codex-rs/core/src/tools/spec_tests.rs`
 
 Current effect:
 


### PR DESCRIPTION
## What changed

- hides `spawn_agent` from thread-spawned sub-agents while preserving the E-witness collaboration tools they still need for supervision
- adds regression coverage for both v1 and v2 collaboration tool surfaces
- keeps the small `compact.rs` argument-comment cleanup needed for the current comment-lint rules
- adds maintainer docs for the fork-owned module inventory and the implemented governance/runtime surface
- refreshes the inventory doc so `p5` is recorded as merged on `origin/main` and this branch-local tool-containment patch is documented separately

## Why

- thread-spawned children were still receiving `spawn_agent`, which let them recurse into further delegation even when we only wanted one execution lane
- the fork-maintainer docs were missing from git and the inventory still treated `p5` as pending after it had already landed on `origin/main`

## User / developer impact

- thread-spawned sub-agents keep `inspect_agent_progress`, `wait_for_agent_progress`, and the normal wait/send/close controls, but they no longer get `spawn_agent`
- future upstream ingests now have an explicit doc inventory of the fork-owned bundles and hot files

## Root cause

- the thread-spawn collaboration surface was exposing the same spawn tool as the root/session surface, so child lanes could recursively orchestrate instead of remaining bounded

## Validation

- `cargo test -p codex-core`
  - new coverage passed: `test_build_specs_thread_spawn_subagent_hides_spawn_agent_tool_v1` and `test_build_specs_thread_spawn_subagent_hides_spawn_agent_tool_v2`
  - package run still has the existing unrelated failures in `shell_snapshot` / `unified_exec`:
    - `shell_snapshot::tests::snapshot_shell_does_not_inherit_stdin`
    - `shell_snapshot::tests::timed_out_snapshot_shell_is_terminated`
    - `unified_exec::tests::completed_pipe_commands_preserve_exit_code`
    - `unified_exec::tests::reusing_completed_process_returns_unknown_process`
    - `unified_exec::tests::unified_exec_pause_blocks_yield_timeout`
    - `unified_exec::tests::unified_exec_timeouts`
- `just fix -p codex-core`
- `just fmt`
- `./tools/argument-comment-lint/run.py`