### PR TITLE
[codex] Decouple context policy governance from config schema

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1894,7 +1894,6 @@ dependencies = [
 name = "codex-context-maintenance-policy"
 version = "0.121.0"
 dependencies = [
- "codex-config",
  "codex-protocol",
  "pretty_assertions",
  "serde",

--- a/codex-rs/context-maintenance-policy/Cargo.toml
+++ b/codex-rs/context-maintenance-policy/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-codex-config = { workspace = true }
 codex-protocol = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/codex-rs/context-maintenance-policy/src/contracts.rs
+++ b/codex-rs/context-maintenance-policy/src/contracts.rs
@@ -1,4 +1,3 @@
-use codex_config::config_toml::GovernancePathVariant;
 use thiserror::Error;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -61,11 +60,17 @@ pub enum GovernanceEffect {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ThreadMemoryGovernance {
+    Disabled,
+    Enabled,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MaintenancePlanningRequest {
     pub action: MaintenanceAction,
     pub timing: MaintenanceTiming,
     pub engine: PolicyEngine,
-    pub governance_variant: GovernancePathVariant,
+    pub thread_memory_governance: ThreadMemoryGovernance,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/codex-rs/context-maintenance-policy/src/lib.rs
+++ b/codex-rs/context-maintenance-policy/src/lib.rs
@@ -34,6 +34,7 @@ pub use contracts::MaintenancePolicyError;
 pub use contracts::MaintenancePolicyPlan;
 pub use contracts::MaintenanceTiming;
 pub use contracts::PolicyEngine;
+pub use contracts::ThreadMemoryGovernance;
 pub use history_shape::RemoteCompactedHistoryShapeRequest;
 pub use history_shape::insert_initial_context_before_last_real_user_or_summary;
 pub use history_shape::insert_items_before_last_summary_or_compaction;

--- a/codex-rs/context-maintenance-policy/src/route_matrix.rs
+++ b/codex-rs/context-maintenance-policy/src/route_matrix.rs
@@ -1,5 +1,3 @@
-use codex_config::config_toml::GovernancePathVariant;
-
 use crate::ArtifactKind;
 use crate::ArtifactLifetime;
 use crate::ArtifactRequest;
@@ -12,6 +10,7 @@ use crate::MaintenancePolicyError;
 use crate::MaintenancePolicyPlan;
 use crate::MaintenanceTiming;
 use crate::PolicyEngine;
+use crate::ThreadMemoryGovernance;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct BaseRoutePlan {
@@ -27,7 +26,7 @@ pub fn plan_route(
     let base_plan = select_base_route_plan(request.action, request.timing, request.engine)?;
     Ok(apply_governance_overlay(
         base_plan,
-        request.governance_variant,
+        request.thread_memory_governance,
     ))
 }
 
@@ -164,11 +163,11 @@ fn select_base_route_plan(
 
 fn apply_governance_overlay(
     mut base_plan: BaseRoutePlan,
-    governance_variant: GovernancePathVariant,
+    thread_memory_governance: ThreadMemoryGovernance,
 ) -> MaintenancePolicyPlan {
     let mut governance_effects = Vec::new();
 
-    if governance_variant == GovernancePathVariant::Off
+    if thread_memory_governance == ThreadMemoryGovernance::Disabled
         && remove_artifact(
             &mut base_plan.requested_artifacts,
             ArtifactKind::ThreadMemory,

--- a/codex-rs/context-maintenance-policy/src/tests.rs
+++ b/codex-rs/context-maintenance-policy/src/tests.rs
@@ -1,4 +1,3 @@
-use codex_config::config_toml::GovernancePathVariant;
 use pretty_assertions::assert_eq;
 
 use crate::ArtifactKind;
@@ -13,6 +12,7 @@ use crate::MaintenancePolicyError;
 use crate::MaintenancePolicyPlan;
 use crate::MaintenanceTiming;
 use crate::PolicyEngine;
+use crate::ThreadMemoryGovernance;
 use crate::plan_route;
 
 #[test]
@@ -21,7 +21,7 @@ fn compact_intra_turn_local_pure_requests_turn_scoped_bridge() {
         action: MaintenanceAction::Compact,
         timing: MaintenanceTiming::IntraTurn,
         engine: PolicyEngine::LocalPure,
-        governance_variant: GovernancePathVariant::StrictV1Shadow,
+        thread_memory_governance: ThreadMemoryGovernance::Enabled,
     })
     .expect("local pure intra-turn compact should be supported");
 
@@ -46,7 +46,7 @@ fn compact_turn_boundary_local_pure_requests_durable_thread_memory() {
         action: MaintenanceAction::Compact,
         timing: MaintenanceTiming::TurnBoundary,
         engine: PolicyEngine::LocalPure,
-        governance_variant: GovernancePathVariant::StrictV1Shadow,
+        thread_memory_governance: ThreadMemoryGovernance::Enabled,
     })
     .expect("local pure turn-boundary compact should be supported");
 
@@ -74,7 +74,7 @@ fn compact_turn_boundary_governance_off_suppresses_thread_memory() {
         action: MaintenanceAction::Compact,
         timing: MaintenanceTiming::TurnBoundary,
         engine: PolicyEngine::LocalPure,
-        governance_variant: GovernancePathVariant::Off,
+        thread_memory_governance: ThreadMemoryGovernance::Disabled,
     })
     .expect("governance off should still support local pure compact");
 
@@ -99,7 +99,7 @@ fn compact_turn_boundary_remote_vanilla_preserves_legacy_marker_without_fork_art
         action: MaintenanceAction::Compact,
         timing: MaintenanceTiming::TurnBoundary,
         engine: PolicyEngine::RemoteVanilla,
-        governance_variant: GovernancePathVariant::StrictV1Shadow,
+        thread_memory_governance: ThreadMemoryGovernance::Enabled,
     })
     .expect("remote vanilla turn-boundary compact should be supported");
 
@@ -124,7 +124,7 @@ fn refresh_turn_boundary_local_pure_requests_durable_thread_memory() {
         action: MaintenanceAction::Refresh,
         timing: MaintenanceTiming::TurnBoundary,
         engine: PolicyEngine::LocalPure,
-        governance_variant: GovernancePathVariant::StrictV1Shadow,
+        thread_memory_governance: ThreadMemoryGovernance::Enabled,
     })
     .expect("local pure refresh should be supported");
 
@@ -152,7 +152,7 @@ fn refresh_turn_boundary_remote_vanilla_is_unsupported() {
         action: MaintenanceAction::Refresh,
         timing: MaintenanceTiming::TurnBoundary,
         engine: PolicyEngine::RemoteVanilla,
-        governance_variant: GovernancePathVariant::StrictV1Shadow,
+        thread_memory_governance: ThreadMemoryGovernance::Enabled,
     });
 
     assert_eq!(
@@ -171,7 +171,7 @@ fn refresh_intra_turn_is_unsupported() {
         action: MaintenanceAction::Refresh,
         timing: MaintenanceTiming::IntraTurn,
         engine: PolicyEngine::LocalPure,
-        governance_variant: GovernancePathVariant::StrictV1Shadow,
+        thread_memory_governance: ThreadMemoryGovernance::Enabled,
     });
 
     assert_eq!(
@@ -190,7 +190,7 @@ fn prune_turn_boundary_requests_marker_only_prune_manifest() {
         action: MaintenanceAction::Prune,
         timing: MaintenanceTiming::TurnBoundary,
         engine: PolicyEngine::RemoteHybrid,
-        governance_variant: GovernancePathVariant::StrictV1Shadow,
+        thread_memory_governance: ThreadMemoryGovernance::Enabled,
     })
     .expect("turn-boundary prune should be supported");
 

--- a/codex-rs/core/src/context_maintenance_runtime.rs
+++ b/codex-rs/core/src/context_maintenance_runtime.rs
@@ -12,6 +12,7 @@ use codex_context_maintenance_policy::MaintenancePolicyError;
 use codex_context_maintenance_policy::MaintenancePolicyPlan;
 use codex_context_maintenance_policy::MaintenanceTiming;
 use codex_context_maintenance_policy::PolicyEngine;
+use codex_context_maintenance_policy::ThreadMemoryGovernance;
 use codex_context_maintenance_policy::plan_route;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
@@ -85,7 +86,7 @@ pub(crate) fn live_compact_route_behavior_for_tests(
             CompactTimingForTests::IntraTurn => MaintenanceTiming::IntraTurn,
         },
         engine: policy_engine(engine),
-        governance_variant: policy_governance_variant(governance_variant),
+        thread_memory_governance: policy_thread_memory_governance(governance_variant),
     })
     .expect("compact test route should plan")
 }
@@ -120,7 +121,7 @@ pub(crate) fn try_live_turn_boundary_maintenance_behavior_for_tests(
         },
         timing: MaintenanceTiming::TurnBoundary,
         engine: policy_engine(engine),
-        governance_variant: policy_governance_variant(governance_variant),
+        thread_memory_governance: policy_thread_memory_governance(governance_variant),
     })
 }
 
@@ -132,7 +133,9 @@ pub(crate) fn runtime_plan_for_compact(
         action: MaintenanceAction::Compact,
         timing,
         engine: policy_engine(compaction_engine(turn_context)),
-        governance_variant: policy_governance_variant(turn_context.governance_path_variant()),
+        thread_memory_governance: policy_thread_memory_governance(
+            turn_context.governance_path_variant(),
+        ),
     })
 }
 
@@ -144,7 +147,9 @@ pub(crate) fn runtime_plan_for_turn_boundary_maintenance(
         action,
         timing: MaintenanceTiming::TurnBoundary,
         engine: policy_engine(compaction_engine(turn_context)),
-        governance_variant: policy_governance_variant(turn_context.governance_path_variant()),
+        thread_memory_governance: policy_thread_memory_governance(
+            turn_context.governance_path_variant(),
+        ),
     })
 }
 
@@ -193,16 +198,10 @@ fn policy_engine(engine: CompactionEngine) -> PolicyEngine {
     }
 }
 
-fn policy_governance_variant(
-    variant: GovernancePathVariant,
-) -> codex_config::config_toml::GovernancePathVariant {
+fn policy_thread_memory_governance(variant: GovernancePathVariant) -> ThreadMemoryGovernance {
     match variant {
-        GovernancePathVariant::Off => codex_config::config_toml::GovernancePathVariant::Off,
-        GovernancePathVariant::StrictV1Shadow => {
-            codex_config::config_toml::GovernancePathVariant::StrictV1Shadow
-        }
-        GovernancePathVariant::StrictV1Enforce => {
-            codex_config::config_toml::GovernancePathVariant::StrictV1Enforce
-        }
+        GovernancePathVariant::Off => ThreadMemoryGovernance::Disabled,
+        GovernancePathVariant::StrictV1Shadow => ThreadMemoryGovernance::Enabled,
+        GovernancePathVariant::StrictV1Enforce => ThreadMemoryGovernance::Enabled,
     }
 }


### PR DESCRIPTION
## What changed

This PR implements the first hardening slice for the context-maintenance policy boundary: governance decoupling.

- removes the policy crate's direct dependency on `codex-config`
- replaces the policy-side governance input with a policy-owned `ThreadMemoryGovernance` enum
- updates the policy route matrix and tests to use the policy-owned governance axis
- updates the core runtime adapter to translate `GovernancePathVariant` into the policy enum

## Why it changed

The merged extraction still left one clean but important boundary leak: `codex-context-maintenance-policy` depended on the TOML/config schema through `codex_config::config_toml::GovernancePathVariant`.

This PR removes that leak without changing the route matrix. The policy crate now accepts a narrow policy-owned governance input that only captures what route planning actually needs today: whether thread memory is enabled or suppressed.

## Impact

- no intended route-law change
- no intended visible runtime behavior change
- the policy crate boundary is cleaner and less sensitive to future config-schema churn

## Validation

- `cargo test -p codex-context-maintenance-policy`
- `cargo test -p codex-core compaction_policy_matrix_tests --lib`
- `just fix -p codex-context-maintenance-policy`
- `just fmt`

I also attempted `just fix -p codex-core`. The command progressed through the full crate graph, but the shell session did not return a clean completion line after reaching the final `core_test_support` phase, which matches the intermittent long-tail shell/lock behavior seen earlier in this repo.
