### PR TITLE
[codex] Preserve executable artifact requests in runtime plans

### DIFF
--- a/codex-rs/context-maintenance-policy/src/contracts.rs
+++ b/codex-rs/context-maintenance-policy/src/contracts.rs
@@ -34,6 +34,12 @@ pub enum ArtifactLifetime {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArtifactRequiredness {
+    Required,
+    BestEffort,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ArtifactKind {
     ThreadMemory,
     ContinuationBridge,
@@ -45,6 +51,7 @@ pub enum ArtifactKind {
 pub struct ArtifactRequest {
     pub kind: ArtifactKind,
     pub lifetime: ArtifactLifetime,
+    pub requiredness: ArtifactRequiredness,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/codex-rs/context-maintenance-policy/src/lib.rs
+++ b/codex-rs/context-maintenance-policy/src/lib.rs
@@ -25,6 +25,7 @@ pub use continuation_bridge::parse_continuation_bridge_payload;
 pub use contracts::ArtifactKind;
 pub use contracts::ArtifactLifetime;
 pub use contracts::ArtifactRequest;
+pub use contracts::ArtifactRequiredness;
 pub use contracts::ContextInjectionPolicy;
 pub use contracts::GovernanceEffect;
 pub use contracts::LegacyCompactionMarkerPolicy;

--- a/codex-rs/context-maintenance-policy/src/route_matrix.rs
+++ b/codex-rs/context-maintenance-policy/src/route_matrix.rs
@@ -1,6 +1,7 @@
 use crate::ArtifactKind;
 use crate::ArtifactLifetime;
 use crate::ArtifactRequest;
+use crate::ArtifactRequiredness;
 use crate::ContextInjectionPolicy;
 use crate::GovernanceEffect;
 use crate::LegacyCompactionMarkerPolicy;
@@ -42,6 +43,7 @@ fn select_base_route_plan(
                 requested_artifacts: vec![artifact(
                     ArtifactKind::ContinuationBridge,
                     ArtifactLifetime::TurnScoped,
+                    ArtifactRequiredness::BestEffort,
                 )],
                 drop_prior_artifact_kinds: vec![ArtifactKind::ContinuationBridge],
                 legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy::Strip,
@@ -53,6 +55,7 @@ fn select_base_route_plan(
                 requested_artifacts: vec![artifact(
                     ArtifactKind::ContinuationBridge,
                     ArtifactLifetime::TurnScoped,
+                    ArtifactRequiredness::BestEffort,
                 )],
                 drop_prior_artifact_kinds: vec![ArtifactKind::ContinuationBridge],
                 legacy_compaction_marker_policy:
@@ -73,6 +76,7 @@ fn select_base_route_plan(
                 requested_artifacts: vec![artifact(
                     ArtifactKind::ThreadMemory,
                     ArtifactLifetime::DurableAcrossTurns,
+                    ArtifactRequiredness::Required,
                 )],
                 drop_prior_artifact_kinds: vec![
                     ArtifactKind::ThreadMemory,
@@ -90,6 +94,7 @@ fn select_base_route_plan(
             requested_artifacts: vec![artifact(
                 ArtifactKind::ThreadMemory,
                 ArtifactLifetime::DurableAcrossTurns,
+                ArtifactRequiredness::Required,
             )],
             drop_prior_artifact_kinds: vec![
                 ArtifactKind::ThreadMemory,
@@ -117,6 +122,7 @@ fn select_base_route_plan(
                 requested_artifacts: vec![artifact(
                     ArtifactKind::ThreadMemory,
                     ArtifactLifetime::DurableAcrossTurns,
+                    ArtifactRequiredness::Required,
                 )],
                 drop_prior_artifact_kinds: vec![
                     ArtifactKind::ThreadMemory,
@@ -134,6 +140,7 @@ fn select_base_route_plan(
             requested_artifacts: vec![artifact(
                 ArtifactKind::ThreadMemory,
                 ArtifactLifetime::DurableAcrossTurns,
+                ArtifactRequiredness::Required,
             )],
             drop_prior_artifact_kinds: vec![
                 ArtifactKind::ThreadMemory,
@@ -146,6 +153,7 @@ fn select_base_route_plan(
             requested_artifacts: vec![artifact(
                 ArtifactKind::PruneManifest,
                 ArtifactLifetime::MarkerOnly,
+                ArtifactRequiredness::Required,
             )],
             drop_prior_artifact_kinds: vec![
                 ArtifactKind::PruneManifest,
@@ -185,8 +193,16 @@ fn apply_governance_overlay(
     }
 }
 
-fn artifact(kind: ArtifactKind, lifetime: ArtifactLifetime) -> ArtifactRequest {
-    ArtifactRequest { kind, lifetime }
+fn artifact(
+    kind: ArtifactKind,
+    lifetime: ArtifactLifetime,
+    requiredness: ArtifactRequiredness,
+) -> ArtifactRequest {
+    ArtifactRequest {
+        kind,
+        lifetime,
+        requiredness,
+    }
 }
 
 fn remove_artifact(artifacts: &mut Vec<ArtifactRequest>, kind: ArtifactKind) -> bool {

--- a/codex-rs/context-maintenance-policy/src/tests.rs
+++ b/codex-rs/context-maintenance-policy/src/tests.rs
@@ -3,6 +3,7 @@ use pretty_assertions::assert_eq;
 use crate::ArtifactKind;
 use crate::ArtifactLifetime;
 use crate::ArtifactRequest;
+use crate::ArtifactRequiredness;
 use crate::ContextInjectionPolicy;
 use crate::GovernanceEffect;
 use crate::LegacyCompactionMarkerPolicy;
@@ -32,6 +33,7 @@ fn compact_intra_turn_local_pure_requests_turn_scoped_bridge() {
             requested_artifacts: vec![ArtifactRequest {
                 kind: ArtifactKind::ContinuationBridge,
                 lifetime: ArtifactLifetime::TurnScoped,
+                requiredness: ArtifactRequiredness::BestEffort,
             }],
             drop_prior_artifact_kinds: vec![ArtifactKind::ContinuationBridge],
             legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy::Strip,
@@ -57,6 +59,7 @@ fn compact_turn_boundary_local_pure_requests_durable_thread_memory() {
             requested_artifacts: vec![ArtifactRequest {
                 kind: ArtifactKind::ThreadMemory,
                 lifetime: ArtifactLifetime::DurableAcrossTurns,
+                requiredness: ArtifactRequiredness::Required,
             }],
             drop_prior_artifact_kinds: vec![
                 ArtifactKind::ThreadMemory,
@@ -135,6 +138,7 @@ fn refresh_turn_boundary_local_pure_requests_durable_thread_memory() {
             requested_artifacts: vec![ArtifactRequest {
                 kind: ArtifactKind::ThreadMemory,
                 lifetime: ArtifactLifetime::DurableAcrossTurns,
+                requiredness: ArtifactRequiredness::Required,
             }],
             drop_prior_artifact_kinds: vec![
                 ArtifactKind::ThreadMemory,
@@ -201,6 +205,7 @@ fn prune_turn_boundary_requests_marker_only_prune_manifest() {
             requested_artifacts: vec![ArtifactRequest {
                 kind: ArtifactKind::PruneManifest,
                 lifetime: ArtifactLifetime::MarkerOnly,
+                requiredness: ArtifactRequiredness::Required,
             }],
             drop_prior_artifact_kinds: vec![
                 ArtifactKind::PruneManifest,

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -12,6 +12,7 @@ use crate::codex::get_last_assistant_message_from_turn;
 use crate::config::CompactionEngine;
 use crate::context_maintenance_config::resolve_context_maintenance_request_context;
 use crate::context_maintenance_runtime::compact_timing_from_initial_context_injection;
+use crate::context_maintenance_runtime::execute_requested_artifact;
 use crate::context_maintenance_runtime::runtime_plan_for_compact;
 use crate::continuation_bridge::generate_continuation_bridge_item;
 use crate::governance::thread_memory::generate_thread_memory_item;
@@ -46,7 +47,6 @@ use codex_utils_output_truncation::approx_token_count;
 use codex_utils_output_truncation::truncate_text;
 use futures::prelude::*;
 use tracing::error;
-use tracing::warn;
 
 pub const SUMMARIZATION_PROMPT: &str = include_str!("../templates/compact/prompt.md");
 pub const SUMMARY_PREFIX: &str = include_str!("../templates/compact/summary_prefix.md");
@@ -179,54 +179,42 @@ async fn run_compact_task_inner_impl(
     let history_for_artifacts = history
         .clone()
         .for_prompt(&turn_context.model_info.input_modalities);
-    let thread_memory_item = if runtime_plan.requests_artifact(ArtifactKind::ThreadMemory) {
-        match generate_thread_memory_item(
-            &sess,
-            turn_context.as_ref(),
-            history_for_artifacts.clone(),
-        )
-        .await
-        {
-            Ok(Some(item)) => Some(item),
-            Ok(None) => {
-                let err = CodexErr::Fatal("required thread memory generation returned empty output before local compaction".to_string());
-                sess.send_event(
-                    &turn_context,
-                    EventMsg::Error(err.to_error_event(/*message_prefix*/ None)),
-                )
-                .await;
-                return Err(err);
-            }
-            Err(err) => {
-                let err = CodexErr::Fatal(format!(
-                    "failed generating required thread memory before local compaction: {err}"
-                ));
-                sess.send_event(
-                    &turn_context,
-                    EventMsg::Error(err.to_error_event(/*message_prefix*/ None)),
-                )
-                .await;
-                return Err(err);
-            }
+    let thread_memory_item = match execute_requested_artifact(
+        runtime_plan.artifact_requiredness(ArtifactKind::ThreadMemory),
+        "thread memory",
+        "before local compaction",
+        || generate_thread_memory_item(&sess, turn_context.as_ref(), history_for_artifacts.clone()),
+    )
+    .await
+    {
+        Ok(item) => item,
+        Err(err) => {
+            sess.send_event(
+                &turn_context,
+                EventMsg::Error(err.to_error_event(/*message_prefix*/ None)),
+            )
+            .await;
+            return Err(err);
         }
-    } else {
-        None
     };
     let thread_memory_present = thread_memory_item.is_some();
-    let continuation_bridge_item = if runtime_plan
-        .requests_artifact(ArtifactKind::ContinuationBridge)
+    let continuation_bridge_item = match execute_requested_artifact(
+        runtime_plan.artifact_requiredness(ArtifactKind::ContinuationBridge),
+        "continuation bridge",
+        "before local compaction",
+        || generate_continuation_bridge_item(&sess, turn_context.as_ref(), history_for_artifacts),
+    )
+    .await
     {
-        match generate_continuation_bridge_item(&sess, turn_context.as_ref(), history_for_artifacts)
-            .await
-        {
-            Ok(item) => item,
-            Err(err) => {
-                warn!("failed generating continuation bridge before local compaction: {err}");
-                None
-            }
+        Ok(item) => item,
+        Err(err) => {
+            sess.send_event(
+                &turn_context,
+                EventMsg::Error(err.to_error_event(/*message_prefix*/ None)),
+            )
+            .await;
+            return Err(err);
         }
-    } else {
-        None
     };
     let authoritative_items: Vec<_> = thread_memory_item
         .into_iter()

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -13,6 +13,7 @@ use crate::compact::is_raw_conversation_message;
 use crate::compact::is_real_user_message;
 use crate::compact::is_user_or_summary_message;
 use crate::context_maintenance_runtime::compact_timing_from_initial_context_injection;
+use crate::context_maintenance_runtime::execute_requested_artifact;
 use crate::context_maintenance_runtime::runtime_plan_for_compact;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
@@ -41,7 +42,6 @@ use futures::TryFutureExt;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 use tracing::info;
-use tracing::warn;
 
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
@@ -172,46 +172,27 @@ async fn run_remote_compact_task_inner_impl(
         personality: turn_context.personality,
         output_schema: None,
     };
-    let thread_memory_item = if runtime_plan.requests_artifact(ArtifactKind::ThreadMemory) {
-        match generate_thread_memory_item(
-            sess.as_ref(),
-            turn_context.as_ref(),
-            prompt.input.clone(),
-        )
-        .await
-        {
-            Ok(Some(item)) => Some(item),
-            Ok(None) => {
-                return Err(CodexErr::Fatal("required thread memory generation returned empty output before remote compaction".to_string()));
-            }
-            Err(err) => {
-                return Err(CodexErr::Fatal(format!(
-                    "failed generating required thread memory before remote compaction: {err}"
-                )));
-            }
-        }
-    } else {
-        None
-    };
+    let thread_memory_item = execute_requested_artifact(
+        runtime_plan.artifact_requiredness(ArtifactKind::ThreadMemory),
+        "thread memory",
+        "before remote compaction",
+        || generate_thread_memory_item(sess.as_ref(), turn_context.as_ref(), prompt.input.clone()),
+    )
+    .await?;
     let thread_memory_present = thread_memory_item.is_some();
-    let continuation_bridge_item =
-        if runtime_plan.requests_artifact(ArtifactKind::ContinuationBridge) {
-            match generate_continuation_bridge_item(
+    let continuation_bridge_item = execute_requested_artifact(
+        runtime_plan.artifact_requiredness(ArtifactKind::ContinuationBridge),
+        "continuation bridge",
+        "before remote compaction",
+        || {
+            generate_continuation_bridge_item(
                 sess.as_ref(),
                 turn_context.as_ref(),
                 prompt.input.clone(),
             )
-            .await
-            {
-                Ok(item) => item,
-                Err(err) => {
-                    warn!("failed generating continuation bridge before remote compaction: {err}");
-                    None
-                }
-            }
-        } else {
-            None
-        };
+        },
+    )
+    .await?;
 
     let mut new_history = sess
         .services

--- a/codex-rs/core/src/compaction_policy_matrix_tests.rs
+++ b/codex-rs/core/src/compaction_policy_matrix_tests.rs
@@ -6,6 +6,7 @@ use crate::context_maintenance_runtime::live_compact_route_behavior_for_tests;
 use crate::context_maintenance_runtime::live_turn_boundary_maintenance_behavior_for_tests;
 use crate::context_maintenance_runtime::try_live_turn_boundary_maintenance_behavior_for_tests;
 use codex_context_maintenance_policy::ArtifactKind;
+use codex_context_maintenance_policy::ArtifactRequiredness;
 use codex_context_maintenance_policy::GovernanceEffect;
 use pretty_assertions::assert_eq;
 
@@ -26,6 +27,10 @@ fn live_local_pure_intra_turn_compact_is_bridge_only() {
         true
     );
     assert_eq!(
+        behavior.artifact_requiredness(ArtifactKind::ContinuationBridge),
+        Some(ArtifactRequiredness::BestEffort)
+    );
+    assert_eq!(
         behavior.drops_prior_artifact(ArtifactKind::ContinuationBridge),
         true
     );
@@ -40,6 +45,10 @@ fn live_remote_hybrid_turn_boundary_compact_is_thread_memory_only() {
     );
 
     assert_eq!(behavior.requests_artifact(ArtifactKind::ThreadMemory), true);
+    assert_eq!(
+        behavior.artifact_requiredness(ArtifactKind::ThreadMemory),
+        Some(ArtifactRequiredness::Required)
+    );
     assert_eq!(
         behavior.requests_artifact(ArtifactKind::ContinuationBridge),
         false
@@ -82,6 +91,10 @@ fn live_refresh_is_thread_memory_only_for_supported_engines() {
         );
 
         assert_eq!(behavior.requests_artifact(ArtifactKind::ThreadMemory), true);
+        assert_eq!(
+            behavior.artifact_requiredness(ArtifactKind::ThreadMemory),
+            Some(ArtifactRequiredness::Required)
+        );
         assert_eq!(
             behavior.requests_artifact(ArtifactKind::ContinuationBridge),
             false
@@ -135,6 +148,10 @@ fn live_prune_is_manifest_only_and_drops_turn_scoped_bridge() {
     assert_eq!(
         behavior.requests_artifact(ArtifactKind::PruneManifest),
         true
+    );
+    assert_eq!(
+        behavior.artifact_requiredness(ArtifactKind::PruneManifest),
+        Some(ArtifactRequiredness::Required)
     );
     assert_eq!(
         behavior.drops_prior_artifact(ArtifactKind::ContinuationBridge),

--- a/codex-rs/core/src/context_maintenance.rs
+++ b/codex-rs/core/src/context_maintenance.rs
@@ -6,6 +6,7 @@ use crate::compact::COMPACT_RAW_CONVERSATION_WINDOW_MESSAGES;
 use crate::compact::insert_items_before_last_summary_or_compaction;
 use crate::compact::is_summary_message;
 use crate::compact::retain_recent_raw_conversation_messages;
+use crate::context_maintenance_runtime::execute_requested_artifact;
 use crate::context_maintenance_runtime::runtime_plan_for_turn_boundary_maintenance;
 use crate::governance::thread_memory::generate_thread_memory_item;
 use codex_context_maintenance_policy::ArtifactKind;
@@ -14,7 +15,6 @@ use codex_context_maintenance_policy::build_prune_manifest_item;
 use codex_context_maintenance_policy::prune_superseded_artifacts;
 use codex_context_maintenance_policy::remove_artifact_kind;
 use codex_context_maintenance_policy::tagged_artifact_kind;
-use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
 use codex_protocol::items::ContextCompactionItem;
 use codex_protocol::items::TurnItem;
@@ -40,30 +40,19 @@ pub(crate) async fn run_refresh(
     let prompt_history = history_snapshot
         .clone()
         .for_prompt(&turn_context.model_info.input_modalities);
-    let thread_memory_item = if runtime_plan.requests_artifact(ArtifactKind::ThreadMemory) {
-        match generate_thread_memory_item(
-            sess.as_ref(),
-            turn_context.as_ref(),
-            prompt_history.clone(),
-        )
-        .await
-        {
-            Ok(Some(item)) => Some(item),
-            Ok(None) => {
-                return Err(CodexErr::Fatal(
-                    "required thread memory generation returned empty output during /refresh"
-                        .to_string(),
-                ));
-            }
-            Err(err) => {
-                return Err(CodexErr::Fatal(format!(
-                    "failed generating required thread memory during /refresh: {err}"
-                )));
-            }
-        }
-    } else {
-        None
-    };
+    let thread_memory_item = execute_requested_artifact(
+        runtime_plan.artifact_requiredness(ArtifactKind::ThreadMemory),
+        "thread memory",
+        "during /refresh",
+        || {
+            generate_thread_memory_item(
+                sess.as_ref(),
+                turn_context.as_ref(),
+                prompt_history.clone(),
+            )
+        },
+    )
+    .await?;
 
     let (mut new_history, mut removed_count) = prune_superseded_artifacts(raw_history);
     for artifact_kind in runtime_plan.drop_prior_artifact_kinds() {

--- a/codex-rs/core/src/context_maintenance_runtime.rs
+++ b/codex-rs/core/src/context_maintenance_runtime.rs
@@ -100,7 +100,8 @@ where
                 "required {artifact_name} generation returned empty output {operation}"
             ))),
             Err(err) => Err(CodexErr::Fatal(format!(
-                "failed generating required {artifact_name} {operation}: {err}"
+                "failed generating required {artifact_name} {operation}: {}",
+                required_artifact_error_detail(err)
             ))),
         },
         Some(ArtifactRequiredness::BestEffort) => match generate().await {
@@ -111,6 +112,13 @@ where
             }
         },
         None => Ok(None),
+    }
+}
+
+fn required_artifact_error_detail(err: CodexErr) -> String {
+    match err {
+        CodexErr::Fatal(message) => message,
+        other => other.to_string(),
     }
 }
 
@@ -320,7 +328,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "Fatal error: failed generating required continuation bridge during test: Fatal error: boom"
+            "Fatal error: failed generating required continuation bridge during test: boom"
         );
     }
 }

--- a/codex-rs/core/src/context_maintenance_runtime.rs
+++ b/codex-rs/core/src/context_maintenance_runtime.rs
@@ -1,8 +1,12 @@
+use std::future::Future;
+
 use crate::codex::TurnContext;
 use crate::compact::InitialContextInjection;
 use crate::config::CompactionEngine;
 use crate::config::GovernancePathVariant;
 use codex_context_maintenance_policy::ArtifactKind;
+use codex_context_maintenance_policy::ArtifactRequest;
+use codex_context_maintenance_policy::ArtifactRequiredness;
 use codex_context_maintenance_policy::ContextInjectionPolicy;
 use codex_context_maintenance_policy::GovernanceEffect;
 use codex_context_maintenance_policy::LegacyCompactionMarkerPolicy;
@@ -16,10 +20,11 @@ use codex_context_maintenance_policy::ThreadMemoryGovernance;
 use codex_context_maintenance_policy::plan_route;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
+use tracing::warn;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RuntimeMaintenancePlan {
-    requested_artifacts: Vec<ArtifactKind>,
+    requested_artifacts: Vec<ArtifactRequest>,
     drop_prior_artifact_kinds: Vec<ArtifactKind>,
     context_injection: ContextInjectionPolicy,
     legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy,
@@ -27,8 +32,20 @@ pub(crate) struct RuntimeMaintenancePlan {
 }
 
 impl RuntimeMaintenancePlan {
+    pub(crate) fn artifact_request(&self, kind: ArtifactKind) -> Option<&ArtifactRequest> {
+        self.requested_artifacts
+            .iter()
+            .find(|artifact| artifact.kind == kind)
+    }
+
+    #[cfg(test)]
     pub(crate) fn requests_artifact(&self, kind: ArtifactKind) -> bool {
-        self.requested_artifacts.contains(&kind)
+        self.artifact_request(kind).is_some()
+    }
+
+    pub(crate) fn artifact_requiredness(&self, kind: ArtifactKind) -> Option<ArtifactRequiredness> {
+        self.artifact_request(kind)
+            .map(|artifact| artifact.requiredness)
     }
 
     #[cfg(test)]
@@ -63,6 +80,37 @@ impl RuntimeMaintenancePlan {
     #[cfg(test)]
     pub(crate) fn governance_effects(&self) -> &[GovernanceEffect] {
         &self.governance_effects
+    }
+}
+
+pub(crate) async fn execute_requested_artifact<T, F, Fut>(
+    requiredness: Option<ArtifactRequiredness>,
+    artifact_name: &str,
+    operation: &str,
+    generate: F,
+) -> CodexResult<Option<T>>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = CodexResult<Option<T>>>,
+{
+    match requiredness {
+        Some(ArtifactRequiredness::Required) => match generate().await {
+            Ok(Some(item)) => Ok(Some(item)),
+            Ok(None) => Err(CodexErr::Fatal(format!(
+                "required {artifact_name} generation returned empty output {operation}"
+            ))),
+            Err(err) => Err(CodexErr::Fatal(format!(
+                "failed generating required {artifact_name} {operation}: {err}"
+            ))),
+        },
+        Some(ArtifactRequiredness::BestEffort) => match generate().await {
+            Ok(item) => Ok(item),
+            Err(err) => {
+                warn!("failed generating {artifact_name} {operation}: {err}");
+                Ok(None)
+            }
+        },
+        None => Ok(None),
     }
 }
 
@@ -174,11 +222,7 @@ fn runtime_plan(request: MaintenancePlanningRequest) -> CodexResult<RuntimeMaint
 
 fn runtime_plan_from_policy_plan(plan: MaintenancePolicyPlan) -> RuntimeMaintenancePlan {
     RuntimeMaintenancePlan {
-        requested_artifacts: plan
-            .requested_artifacts
-            .into_iter()
-            .map(|artifact| artifact.kind)
-            .collect(),
+        requested_artifacts: plan.requested_artifacts,
         drop_prior_artifact_kinds: plan.drop_prior_artifact_kinds,
         context_injection: plan.context_injection,
         legacy_compaction_marker_policy: plan.legacy_compaction_marker_policy,
@@ -203,5 +247,80 @@ fn policy_thread_memory_governance(variant: GovernancePathVariant) -> ThreadMemo
         GovernancePathVariant::Off => ThreadMemoryGovernance::Disabled,
         GovernancePathVariant::StrictV1Shadow => ThreadMemoryGovernance::Enabled,
         GovernancePathVariant::StrictV1Enforce => ThreadMemoryGovernance::Enabled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn execute_requested_artifact_skips_generation_when_not_requested() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_for_closure = Arc::clone(&called);
+
+        let result = execute_requested_artifact(None, "thread memory", "during test", move || {
+            called_for_closure.store(true, Ordering::SeqCst);
+            async { Ok(Some("unused")) }
+        })
+        .await
+        .expect("missing request should skip generation");
+
+        assert_eq!(result, None);
+        assert_eq!(called.load(Ordering::SeqCst), false);
+    }
+
+    #[tokio::test]
+    async fn execute_requested_artifact_fails_when_required_output_is_missing() {
+        let err = execute_requested_artifact(
+            Some(ArtifactRequiredness::Required),
+            "thread memory",
+            "during test",
+            || async { Ok(None::<()>) },
+        )
+        .await
+        .expect_err("required artifact should fail when generation returns no item");
+
+        assert_eq!(
+            err.to_string(),
+            "Fatal error: required thread memory generation returned empty output during test"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_requested_artifact_ignores_best_effort_failures() {
+        let result = execute_requested_artifact(
+            Some(ArtifactRequiredness::BestEffort),
+            "continuation bridge",
+            "during test",
+            || async { Err(CodexErr::Fatal("boom".to_string())) as CodexResult<Option<()>> },
+        )
+        .await
+        .expect("best-effort artifact failures should not fail the runtime path");
+
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn execute_requested_artifact_propagates_required_failures() {
+        let err = execute_requested_artifact(
+            Some(ArtifactRequiredness::Required),
+            "continuation bridge",
+            "during test",
+            || async { Err(CodexErr::Fatal("boom".to_string())) as CodexResult<Option<()>> },
+        )
+        .await
+        .expect_err("required artifact failures should be fatal");
+
+        assert_eq!(
+            err.to_string(),
+            "Fatal error: failed generating required continuation bridge during test: Fatal error: boom"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- preserve full policy-owned `ArtifactRequest` values in runtime plans instead of flattening them to kind-only booleans
- route required vs best-effort artifact execution through one shared runtime helper used by local compact, remote compact, and refresh
- add route assertions and runtime failure-path tests for required and best-effort artifact behavior

## Testing
- `cargo test -p codex-context-maintenance-policy`
- `cargo test -p codex-core context_maintenance_runtime::tests --lib`
- `cargo test -p codex-core compaction_policy_matrix_tests --lib`
- `cargo test -p codex-core compact::tests --lib`
- `cargo test -p codex-core context_maintenance::tests --lib`
- `just fix -p codex-context-maintenance-policy`
- `just fix -p codex-core`
- `just fmt`