### PR TITLE
[codex] Unify context maintenance disposition execution

### DIFF
--- a/codex-rs/context-maintenance-policy/src/artifact_codecs.rs
+++ b/codex-rs/context-maintenance-policy/src/artifact_codecs.rs
@@ -209,18 +209,30 @@ pub fn apply_history_disposition(request: HistoryDispositionRequest) -> HistoryD
         removed_count = removed_count.saturating_add(removed);
     }
 
-    for artifact_kind in request.drop_prior_artifact_kinds {
-        let (next_items, removed) = remove_artifact_kind(items, artifact_kind);
-        items = next_items;
-        removed_count = removed_count.saturating_add(removed);
-    }
-
-    if matches!(
+    let strip_markers = matches!(
         request.legacy_compaction_marker_policy,
         LegacyCompactionMarkerPolicy::Strip
-    ) {
-        let (next_items, removed) = remove_legacy_compaction_markers(items);
-        items = next_items;
+    );
+    if !request.drop_prior_artifact_kinds.is_empty() || strip_markers {
+        let mut removed = 0usize;
+        items = items
+            .into_iter()
+            .filter_map(|item| {
+                if strip_markers && matches!(item, ResponseItem::Compaction { .. }) {
+                    removed = removed.saturating_add(1);
+                    return None;
+                }
+
+                let should_drop_artifact = tagged_artifact_kind(&item)
+                    .is_some_and(|kind| request.drop_prior_artifact_kinds.contains(&kind));
+                if should_drop_artifact {
+                    removed = removed.saturating_add(1);
+                    None
+                } else {
+                    Some(item)
+                }
+            })
+            .collect();
         removed_count = removed_count.saturating_add(removed);
     }
 
@@ -228,22 +240,6 @@ pub fn apply_history_disposition(request: HistoryDispositionRequest) -> HistoryD
         items,
         removed_count,
     }
-}
-
-fn remove_legacy_compaction_markers(items: Vec<ResponseItem>) -> (Vec<ResponseItem>, usize) {
-    let mut removed = 0usize;
-    let items = items
-        .into_iter()
-        .filter_map(|item| {
-            if matches!(item, ResponseItem::Compaction { .. }) {
-                removed = removed.saturating_add(1);
-                None
-            } else {
-                Some(item)
-            }
-        })
-        .collect();
-    (items, removed)
 }
 
 #[cfg(test)]

--- a/codex-rs/context-maintenance-policy/src/artifact_codecs.rs
+++ b/codex-rs/context-maintenance-policy/src/artifact_codecs.rs
@@ -4,6 +4,9 @@ use codex_protocol::models::ResponseItem;
 use serde_json::json;
 
 use crate::ArtifactKind;
+use crate::HistoryDispositionRequest;
+use crate::HistoryDispositionResult;
+use crate::LegacyCompactionMarkerPolicy;
 
 const CONTINUATION_BRIDGE_TAG: &str = "continuation_bridge";
 const THREAD_MEMORY_TAG: &str = "thread_memory";
@@ -196,12 +199,60 @@ pub fn build_prune_manifest_item(
     })
 }
 
+pub fn apply_history_disposition(request: HistoryDispositionRequest) -> HistoryDispositionResult {
+    let mut removed_count = 0usize;
+    let mut items = request.items;
+
+    if request.prune_superseded_artifacts {
+        let (next_items, removed) = prune_superseded_artifacts(items);
+        items = next_items;
+        removed_count = removed_count.saturating_add(removed);
+    }
+
+    for artifact_kind in request.drop_prior_artifact_kinds {
+        let (next_items, removed) = remove_artifact_kind(items, artifact_kind);
+        items = next_items;
+        removed_count = removed_count.saturating_add(removed);
+    }
+
+    if matches!(
+        request.legacy_compaction_marker_policy,
+        LegacyCompactionMarkerPolicy::Strip
+    ) {
+        let (next_items, removed) = remove_legacy_compaction_markers(items);
+        items = next_items;
+        removed_count = removed_count.saturating_add(removed);
+    }
+
+    HistoryDispositionResult {
+        items,
+        removed_count,
+    }
+}
+
+fn remove_legacy_compaction_markers(items: Vec<ResponseItem>) -> (Vec<ResponseItem>, usize) {
+    let mut removed = 0usize;
+    let items = items
+        .into_iter()
+        .filter_map(|item| {
+            if matches!(item, ResponseItem::Compaction { .. }) {
+                removed = removed.saturating_add(1);
+                None
+            } else {
+                Some(item)
+            }
+        })
+        .collect();
+    (items, removed)
+}
+
 #[cfg(test)]
 mod tests {
     use codex_protocol::models::ContentItem;
     use codex_protocol::models::ResponseItem;
     use pretty_assertions::assert_eq;
 
+    use super::apply_history_disposition;
     use super::build_prune_manifest_item;
     use super::content_items_to_text;
     use super::extract_tagged_payload;
@@ -211,6 +262,9 @@ mod tests {
     use super::tagged_artifact_kind;
     use super::tagged_artifact_kind_from_text;
     use crate::ArtifactKind;
+    use crate::HistoryDispositionRequest;
+    use crate::HistoryDispositionResult;
+    use crate::LegacyCompactionMarkerPolicy;
 
     #[test]
     fn content_items_to_text_joins_text_and_skips_images() {
@@ -367,6 +421,54 @@ mod tests {
                 "<prune_manifest schema=\"prune_manifest_v1\">\n{\n  \"final_history_len\": 7,\n  \"original_history_len\": 10,\n  \"removed_item_count\": 3,\n  \"schema\": \"prune_manifest_v1\"\n}\n</prune_manifest>"
                     .to_string()
             )
+        );
+    }
+
+    #[test]
+    fn apply_history_disposition_prunes_drops_and_strips_markers() {
+        let result = apply_history_disposition(HistoryDispositionRequest {
+            items: vec![
+                developer_message("<thread_memory>old</thread_memory>"),
+                developer_message("<thread_memory>new</thread_memory>"),
+                developer_message("<prune_manifest>old</prune_manifest>"),
+                ResponseItem::Compaction {
+                    encrypted_content: "encrypted".to_string(),
+                },
+            ],
+            prune_superseded_artifacts: true,
+            drop_prior_artifact_kinds: vec![ArtifactKind::PruneManifest],
+            legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy::Strip,
+        });
+
+        assert_eq!(
+            result,
+            HistoryDispositionResult {
+                items: vec![developer_message("<thread_memory>new</thread_memory>")],
+                removed_count: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn apply_history_disposition_preserves_markers_when_policy_requires_it() {
+        let marker = ResponseItem::Compaction {
+            encrypted_content: "encrypted".to_string(),
+        };
+
+        let result = apply_history_disposition(HistoryDispositionRequest {
+            items: vec![marker.clone()],
+            prune_superseded_artifacts: false,
+            drop_prior_artifact_kinds: vec![],
+            legacy_compaction_marker_policy:
+                LegacyCompactionMarkerPolicy::PreserveForUpstreamCompatibility,
+        });
+
+        assert_eq!(
+            result,
+            HistoryDispositionResult {
+                items: vec![marker],
+                removed_count: 0,
+            }
         );
     }
 

--- a/codex-rs/context-maintenance-policy/src/contracts.rs
+++ b/codex-rs/context-maintenance-policy/src/contracts.rs
@@ -61,6 +61,20 @@ pub enum LegacyCompactionMarkerPolicy {
     Strip,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct HistoryDispositionRequest {
+    pub items: Vec<codex_protocol::models::ResponseItem>,
+    pub prune_superseded_artifacts: bool,
+    pub drop_prior_artifact_kinds: Vec<ArtifactKind>,
+    pub legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HistoryDispositionResult {
+    pub items: Vec<codex_protocol::models::ResponseItem>,
+    pub removed_count: usize,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GovernanceEffect {
     ThreadMemorySuppressed,

--- a/codex-rs/context-maintenance-policy/src/history_shape.rs
+++ b/codex-rs/context-maintenance-policy/src/history_shape.rs
@@ -1,6 +1,10 @@
 use codex_protocol::models::ResponseItem;
 
+use crate::ArtifactKind;
 use crate::ContextInjectionPolicy;
+use crate::HistoryDispositionRequest;
+use crate::LegacyCompactionMarkerPolicy;
+use crate::apply_history_disposition;
 use crate::retain_recent_raw_conversation_messages;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -8,6 +12,8 @@ pub struct RemoteCompactedHistoryShapeRequest {
     pub compacted_history: Vec<ResponseItem>,
     pub initial_context: Vec<ResponseItem>,
     pub authoritative_items: Vec<ResponseItem>,
+    pub drop_prior_artifact_kinds: Vec<ArtifactKind>,
+    pub legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy,
     pub raw_message_retention_limit: usize,
     pub context_injection: ContextInjectionPolicy,
     pub retain_recent_raw_messages: bool,
@@ -95,8 +101,14 @@ where
     FUserOrSummary: Fn(&ResponseItem) -> bool,
     FRawConversation: Fn(&ResponseItem) -> bool,
 {
-    let mut compacted_history: Vec<_> = request
-        .compacted_history
+    let disposition = apply_history_disposition(HistoryDispositionRequest {
+        items: request.compacted_history,
+        prune_superseded_artifacts: false,
+        drop_prior_artifact_kinds: request.drop_prior_artifact_kinds,
+        legacy_compaction_marker_policy: request.legacy_compaction_marker_policy,
+    });
+    let mut compacted_history: Vec<_> = disposition
+        .items
         .into_iter()
         .filter(should_keep_item)
         .collect();
@@ -142,7 +154,9 @@ mod tests {
     use super::insert_initial_context_before_last_real_user_or_summary;
     use super::insert_items_before_last_summary_or_compaction;
     use super::shape_remote_compacted_history;
+    use crate::ArtifactKind;
     use crate::ContextInjectionPolicy;
+    use crate::LegacyCompactionMarkerPolicy;
 
     #[test]
     fn initial_context_insertion_keeps_summary_last_when_no_real_user_remains() {
@@ -205,6 +219,8 @@ mod tests {
             ],
             initial_context: vec![message("developer", "fresh context")],
             authoritative_items: vec![message("developer", "thread memory")],
+            drop_prior_artifact_kinds: vec![],
+            legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy::Preserve,
             raw_message_retention_limit: 10,
             context_injection: ContextInjectionPolicy::BeforeLastRealUserOrSummary,
             retain_recent_raw_messages: false,
@@ -226,6 +242,36 @@ mod tests {
                 message("user", "summary"),
             ]
         );
+    }
+
+    #[test]
+    fn remote_history_shaping_applies_marker_policy_and_artifact_drops() {
+        let request = RemoteCompactedHistoryShapeRequest {
+            compacted_history: vec![
+                message("user", "summary"),
+                developer_message("<thread_memory>stale</thread_memory>"),
+                ResponseItem::Compaction {
+                    encrypted_content: "encrypted".to_string(),
+                },
+            ],
+            initial_context: vec![],
+            authoritative_items: vec![],
+            drop_prior_artifact_kinds: vec![ArtifactKind::ThreadMemory],
+            legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy::Strip,
+            raw_message_retention_limit: 10,
+            context_injection: ContextInjectionPolicy::None,
+            retain_recent_raw_messages: false,
+        };
+
+        let refreshed = shape_remote_compacted_history(
+            request,
+            |_| true,
+            is_real_user_message,
+            is_user_or_summary_message,
+            is_raw_conversation_message,
+        );
+
+        assert_eq!(refreshed, vec![message("user", "summary")]);
     }
 
     fn should_keep_item(item: &ResponseItem) -> bool {
@@ -261,6 +307,10 @@ mod tests {
             end_turn: None,
             phase: None,
         }
+    }
+
+    fn developer_message(text: &str) -> ResponseItem {
+        message("developer", text)
     }
 
     fn summary_message(text: &str) -> ResponseItem {

--- a/codex-rs/context-maintenance-policy/src/lib.rs
+++ b/codex-rs/context-maintenance-policy/src/lib.rs
@@ -6,6 +6,7 @@ mod retention;
 mod route_matrix;
 mod thread_memory;
 
+pub use artifact_codecs::apply_history_disposition;
 pub use artifact_codecs::build_prune_manifest_item;
 pub use artifact_codecs::content_items_to_text;
 pub use artifact_codecs::extract_tagged_payload;
@@ -28,6 +29,8 @@ pub use contracts::ArtifactRequest;
 pub use contracts::ArtifactRequiredness;
 pub use contracts::ContextInjectionPolicy;
 pub use contracts::GovernanceEffect;
+pub use contracts::HistoryDispositionRequest;
+pub use contracts::HistoryDispositionResult;
 pub use contracts::LegacyCompactionMarkerPolicy;
 pub use contracts::MaintenanceAction;
 pub use contracts::MaintenancePlanningRequest;

--- a/codex-rs/core/src/codex_tests_guardian.rs
+++ b/codex-rs/core/src/codex_tests_guardian.rs
@@ -248,30 +248,35 @@ async fn process_compacted_history_preserves_separate_guardian_developer_message
     let refreshed = crate::compact_remote::process_compacted_history(
         &session,
         &turn_context,
-        vec![
-            ResponseItem::Message {
-                id: None,
-                role: "developer".to_string(),
-                content: vec![ContentItem::InputText {
-                    text: "stale developer message".to_string(),
-                }],
-                end_turn: None,
-                phase: None,
-            },
-            ResponseItem::Message {
-                id: None,
-                role: "user".to_string(),
-                content: vec![ContentItem::InputText {
-                    text: "summary".to_string(),
-                }],
-                end_turn: None,
-                phase: None,
-            },
-        ],
-        Vec::new(),
-        false,
-        codex_context_maintenance_policy::ContextInjectionPolicy::BeforeLastRealUserOrSummary,
-        /*preserve_legacy_compaction_marker*/ true,
+        crate::compact_remote::ProcessCompactedHistoryRequest {
+            compacted_history: vec![
+                ResponseItem::Message {
+                    id: None,
+                    role: "developer".to_string(),
+                    content: vec![ContentItem::InputText {
+                        text: "stale developer message".to_string(),
+                    }],
+                    end_turn: None,
+                    phase: None,
+                },
+                ResponseItem::Message {
+                    id: None,
+                    role: "user".to_string(),
+                    content: vec![ContentItem::InputText {
+                        text: "summary".to_string(),
+                    }],
+                    end_turn: None,
+                    phase: None,
+                },
+            ],
+            authoritative_items: Vec::new(),
+            retain_recent_raw_messages: false,
+            context_injection:
+                codex_context_maintenance_policy::ContextInjectionPolicy::BeforeLastRealUserOrSummary,
+            drop_prior_artifact_kinds: Vec::new(),
+            legacy_compaction_marker_policy:
+                codex_context_maintenance_policy::LegacyCompactionMarkerPolicy::Preserve,
+        },
     )
     .await;
 

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -43,6 +43,16 @@ use tokio_util::sync::CancellationToken;
 use tracing::error;
 use tracing::info;
 
+pub(crate) struct ProcessCompactedHistoryRequest {
+    pub(crate) compacted_history: Vec<ResponseItem>,
+    pub(crate) authoritative_items: Vec<ResponseItem>,
+    pub(crate) retain_recent_raw_messages: bool,
+    pub(crate) context_injection: ContextInjectionPolicy,
+    pub(crate) drop_prior_artifact_kinds: Vec<ArtifactKind>,
+    pub(crate) legacy_compaction_marker_policy:
+        codex_context_maintenance_policy::LegacyCompactionMarkerPolicy,
+}
+
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
@@ -220,15 +230,18 @@ async fn run_remote_compact_task_inner_impl(
     new_history = process_compacted_history(
         sess.as_ref(),
         turn_context.as_ref(),
-        new_history,
-        thread_memory_item
-            .iter()
-            .cloned()
-            .chain(continuation_bridge_item.iter().cloned())
-            .collect(),
-        thread_memory_present,
-        runtime_plan.context_injection_policy(),
-        runtime_plan.preserves_legacy_compaction_marker(),
+        ProcessCompactedHistoryRequest {
+            compacted_history: new_history,
+            authoritative_items: thread_memory_item
+                .iter()
+                .cloned()
+                .chain(continuation_bridge_item.iter().cloned())
+                .collect(),
+            retain_recent_raw_messages: thread_memory_present,
+            context_injection: runtime_plan.context_injection_policy(),
+            drop_prior_artifact_kinds: runtime_plan.drop_prior_artifact_kinds().to_vec(),
+            legacy_compaction_marker_policy: runtime_plan.legacy_compaction_marker_policy(),
+        },
     )
     .await;
 
@@ -255,17 +268,13 @@ async fn run_remote_compact_task_inner_impl(
 pub(crate) async fn process_compacted_history(
     sess: &Session,
     turn_context: &TurnContext,
-    compacted_history: Vec<ResponseItem>,
-    authoritative_items: Vec<ResponseItem>,
-    retain_recent_raw_messages: bool,
-    context_injection: ContextInjectionPolicy,
-    preserve_legacy_compaction_marker: bool,
+    request: ProcessCompactedHistoryRequest,
 ) -> Vec<ResponseItem> {
     // Mid-turn compaction is the only path that must inject initial context above the last user
     // message in the replacement history. Pre-turn compaction instead injects context after the
     // compaction item, but mid-turn compaction keeps the compaction item last for model training.
     let initial_context = if matches!(
-        context_injection,
+        request.context_injection,
         ContextInjectionPolicy::BeforeLastRealUserOrSummary
     ) {
         sess.build_initial_context(turn_context).await
@@ -275,14 +284,16 @@ pub(crate) async fn process_compacted_history(
 
     shape_remote_compacted_history(
         RemoteCompactedHistoryShapeRequest {
-            compacted_history,
+            compacted_history: request.compacted_history,
             initial_context,
-            authoritative_items,
+            authoritative_items: request.authoritative_items,
+            drop_prior_artifact_kinds: request.drop_prior_artifact_kinds,
+            legacy_compaction_marker_policy: request.legacy_compaction_marker_policy,
             raw_message_retention_limit: COMPACT_RAW_CONVERSATION_WINDOW_MESSAGES,
-            context_injection,
-            retain_recent_raw_messages,
+            context_injection: request.context_injection,
+            retain_recent_raw_messages: request.retain_recent_raw_messages,
         },
-        |item| should_keep_compacted_history_item(item, preserve_legacy_compaction_marker),
+        should_keep_compacted_history_item,
         is_real_user_message,
         is_user_or_summary_message,
         is_raw_conversation_message,
@@ -304,10 +315,7 @@ pub(crate) async fn process_compacted_history(
 /// - `assistant` messages (future remote compaction models may emit them)
 /// - `user`-role warnings and compaction-generated summary messages because
 ///   they parse as `TurnItem::UserMessage`.
-fn should_keep_compacted_history_item(
-    item: &ResponseItem,
-    preserve_legacy_compaction_marker: bool,
-) -> bool {
+fn should_keep_compacted_history_item(item: &ResponseItem) -> bool {
     match item {
         ResponseItem::Message { role, .. } if role == "developer" => false,
         ResponseItem::Message { role, .. } if role == "user" => {
@@ -318,7 +326,7 @@ fn should_keep_compacted_history_item(
         }
         ResponseItem::Message { role, .. } if role == "assistant" => true,
         ResponseItem::Message { .. } => false,
-        ResponseItem::Compaction { .. } => preserve_legacy_compaction_marker,
+        ResponseItem::Compaction { .. } => true,
         ResponseItem::Reasoning { .. }
         | ResponseItem::LocalShellCall { .. }
         | ResponseItem::FunctionCall { .. }

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 async fn process_compacted_history_with_test_session(
     compacted_history: Vec<ResponseItem>,
     previous_turn_settings: Option<&PreviousTurnSettings>,
+    legacy_compaction_marker_policy: codex_context_maintenance_policy::LegacyCompactionMarkerPolicy,
 ) -> (Vec<ResponseItem>, Vec<ResponseItem>) {
     let (session, turn_context) = crate::codex::make_session_and_context().await;
     session
@@ -15,11 +16,15 @@ async fn process_compacted_history_with_test_session(
     let refreshed = crate::compact_remote::process_compacted_history(
         &session,
         &turn_context,
-        compacted_history,
-        Vec::new(),
-        false,
-        codex_context_maintenance_policy::ContextInjectionPolicy::BeforeLastRealUserOrSummary,
-        /*preserve_legacy_compaction_marker*/ true,
+        crate::compact_remote::ProcessCompactedHistoryRequest {
+            compacted_history,
+            authoritative_items: Vec::new(),
+            retain_recent_raw_messages: false,
+            context_injection:
+                codex_context_maintenance_policy::ContextInjectionPolicy::BeforeLastRealUserOrSummary,
+            drop_prior_artifact_kinds: Vec::new(),
+            legacy_compaction_marker_policy,
+        },
     )
     .await;
     (refreshed, initial_context)
@@ -411,6 +416,7 @@ async fn process_compacted_history_replaces_developer_messages() {
     let (refreshed, mut expected) = process_compacted_history_with_test_session(
         compacted_history,
         /*previous_turn_settings*/ None,
+        codex_context_maintenance_policy::LegacyCompactionMarkerPolicy::Preserve,
     )
     .await;
     expected.push(ResponseItem::Message {
@@ -439,6 +445,7 @@ async fn process_compacted_history_reinjects_full_initial_context() {
     let (refreshed, mut expected) = process_compacted_history_with_test_session(
         compacted_history,
         /*previous_turn_settings*/ None,
+        codex_context_maintenance_policy::LegacyCompactionMarkerPolicy::Preserve,
     )
     .await;
     expected.push(ResponseItem::Message {
@@ -518,6 +525,7 @@ keep me updated
     let (refreshed, mut expected) = process_compacted_history_with_test_session(
         compacted_history,
         /*previous_turn_settings*/ None,
+        codex_context_maintenance_policy::LegacyCompactionMarkerPolicy::Preserve,
     )
     .await;
     expected.push(ResponseItem::Message {
@@ -567,6 +575,7 @@ async fn process_compacted_history_inserts_context_before_last_real_user_message
     let (refreshed, initial_context) = process_compacted_history_with_test_session(
         compacted_history,
         /*previous_turn_settings*/ None,
+        codex_context_maintenance_policy::LegacyCompactionMarkerPolicy::Preserve,
     )
     .await;
     let mut expected = vec![
@@ -621,6 +630,7 @@ async fn process_compacted_history_reinjects_model_switch_message() {
     let (refreshed, initial_context) = process_compacted_history_with_test_session(
         compacted_history,
         Some(&previous_turn_settings),
+        codex_context_maintenance_policy::LegacyCompactionMarkerPolicy::Preserve,
     )
     .await;
 
@@ -644,6 +654,83 @@ async fn process_compacted_history_reinjects_model_switch_message() {
         phase: None,
     });
     assert_eq!(refreshed, expected);
+}
+
+#[tokio::test]
+async fn process_compacted_history_strips_legacy_compaction_markers_when_policy_requires_it() {
+    let compacted_history = vec![
+        ResponseItem::Compaction {
+            encrypted_content: "encrypted".to_string(),
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "summary".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+    ];
+
+    let (refreshed, mut expected) = process_compacted_history_with_test_session(
+        compacted_history,
+        /*previous_turn_settings*/ None,
+        codex_context_maintenance_policy::LegacyCompactionMarkerPolicy::Strip,
+    )
+    .await;
+    expected.push(ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "summary".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    });
+
+    assert_eq!(refreshed, expected);
+}
+
+#[tokio::test]
+async fn process_compacted_history_preserves_legacy_compaction_markers_for_upstream_compatibility()
+{
+    let compacted_history = vec![
+        ResponseItem::Compaction {
+            encrypted_content: "encrypted".to_string(),
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "summary".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+    ];
+
+    let (refreshed, mut expected) = process_compacted_history_with_test_session(
+        compacted_history,
+        /*previous_turn_settings*/ None,
+        codex_context_maintenance_policy::LegacyCompactionMarkerPolicy::PreserveForUpstreamCompatibility,
+    )
+    .await;
+    let mut prefixed = vec![ResponseItem::Compaction {
+        encrypted_content: "encrypted".to_string(),
+    }];
+    prefixed.append(&mut expected);
+    prefixed.push(ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "summary".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    });
+
+    assert_eq!(refreshed, prefixed);
 }
 
 #[test]

--- a/codex-rs/core/src/compaction_policy_matrix_tests.rs
+++ b/codex-rs/core/src/compaction_policy_matrix_tests.rs
@@ -8,6 +8,7 @@ use crate::context_maintenance_runtime::try_live_turn_boundary_maintenance_behav
 use codex_context_maintenance_policy::ArtifactKind;
 use codex_context_maintenance_policy::ArtifactRequiredness;
 use codex_context_maintenance_policy::GovernanceEffect;
+use codex_context_maintenance_policy::LegacyCompactionMarkerPolicy;
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -33,6 +34,10 @@ fn live_local_pure_intra_turn_compact_is_bridge_only() {
     assert_eq!(
         behavior.drops_prior_artifact(ArtifactKind::ContinuationBridge),
         true
+    );
+    assert_eq!(
+        behavior.legacy_compaction_marker_policy(),
+        LegacyCompactionMarkerPolicy::Strip
     );
 }
 
@@ -60,6 +65,10 @@ fn live_remote_hybrid_turn_boundary_compact_is_thread_memory_only() {
     assert_eq!(
         behavior.drops_prior_artifact(ArtifactKind::ContinuationBridge),
         true
+    );
+    assert_eq!(
+        behavior.legacy_compaction_marker_policy(),
+        LegacyCompactionMarkerPolicy::PreserveForUpstreamCompatibility
     );
 }
 
@@ -111,6 +120,10 @@ fn live_refresh_is_thread_memory_only_for_supported_engines() {
             behavior.drops_prior_artifact(ArtifactKind::ContinuationBridge),
             true
         );
+        assert_eq!(
+            behavior.legacy_compaction_marker_policy(),
+            LegacyCompactionMarkerPolicy::Strip
+        );
     }
 }
 
@@ -160,5 +173,9 @@ fn live_prune_is_manifest_only_and_drops_turn_scoped_bridge() {
     assert_eq!(
         behavior.drops_prior_artifact(ArtifactKind::PruneManifest),
         true
+    );
+    assert_eq!(
+        behavior.legacy_compaction_marker_policy(),
+        LegacyCompactionMarkerPolicy::Strip
     );
 }

--- a/codex-rs/core/src/context_maintenance.rs
+++ b/codex-rs/core/src/context_maintenance.rs
@@ -11,9 +11,8 @@ use crate::context_maintenance_runtime::runtime_plan_for_turn_boundary_maintenan
 use crate::governance::thread_memory::generate_thread_memory_item;
 use codex_context_maintenance_policy::ArtifactKind;
 use codex_context_maintenance_policy::MaintenanceAction;
+use codex_context_maintenance_policy::apply_history_disposition;
 use codex_context_maintenance_policy::build_prune_manifest_item;
-use codex_context_maintenance_policy::prune_superseded_artifacts;
-use codex_context_maintenance_policy::remove_artifact_kind;
 use codex_context_maintenance_policy::tagged_artifact_kind;
 use codex_protocol::error::Result as CodexResult;
 use codex_protocol::items::ContextCompactionItem;
@@ -54,12 +53,12 @@ pub(crate) async fn run_refresh(
     )
     .await?;
 
-    let (mut new_history, mut removed_count) = prune_superseded_artifacts(raw_history);
-    for artifact_kind in runtime_plan.drop_prior_artifact_kinds() {
-        let (next_history, removed) = remove_artifact_kind(new_history, *artifact_kind);
-        new_history = next_history;
-        removed_count = removed_count.saturating_add(removed);
-    }
+    let disposition = apply_history_disposition(
+        runtime_plan
+            .history_disposition_request(raw_history, /*prune_superseded_artifacts*/ true),
+    );
+    let mut new_history = disposition.items;
+    let mut removed_count = disposition.removed_count;
 
     let authoritative_items: Vec<_> = thread_memory_item.into_iter().collect();
     if !authoritative_items.is_empty() {
@@ -112,12 +111,12 @@ pub(crate) async fn run_prune(
     let raw_history = history_snapshot.raw_items().to_vec();
 
     let original_len = raw_history.len();
-    let (mut pruned_history, mut removed_count) = prune_superseded_artifacts(raw_history);
-    for artifact_kind in runtime_plan.drop_prior_artifact_kinds() {
-        let (next_history, removed) = remove_artifact_kind(pruned_history, *artifact_kind);
-        pruned_history = next_history;
-        removed_count = removed_count.saturating_add(removed);
-    }
+    let disposition = apply_history_disposition(
+        runtime_plan
+            .history_disposition_request(raw_history, /*prune_superseded_artifacts*/ true),
+    );
+    let mut pruned_history = disposition.items;
+    let mut removed_count = disposition.removed_count;
     let (next_history, summary_removed) = retain_latest_summary_message(pruned_history);
     pruned_history = next_history;
     removed_count = removed_count.saturating_add(summary_removed);
@@ -207,6 +206,8 @@ async fn send_turn_started_event(sess: &Session, turn_context: &TurnContext) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codex_context_maintenance_policy::prune_superseded_artifacts;
+    use codex_context_maintenance_policy::remove_artifact_kind;
     use codex_protocol::models::ContentItem;
     use pretty_assertions::assert_eq;
 

--- a/codex-rs/core/src/context_maintenance_runtime.rs
+++ b/codex-rs/core/src/context_maintenance_runtime.rs
@@ -9,6 +9,7 @@ use codex_context_maintenance_policy::ArtifactRequest;
 use codex_context_maintenance_policy::ArtifactRequiredness;
 use codex_context_maintenance_policy::ContextInjectionPolicy;
 use codex_context_maintenance_policy::GovernanceEffect;
+use codex_context_maintenance_policy::HistoryDispositionRequest;
 use codex_context_maintenance_policy::LegacyCompactionMarkerPolicy;
 use codex_context_maintenance_policy::MaintenanceAction;
 use codex_context_maintenance_policy::MaintenancePlanningRequest;
@@ -57,6 +58,19 @@ impl RuntimeMaintenancePlan {
         &self.drop_prior_artifact_kinds
     }
 
+    pub(crate) fn history_disposition_request(
+        &self,
+        items: Vec<codex_protocol::models::ResponseItem>,
+        prune_superseded_artifacts: bool,
+    ) -> HistoryDispositionRequest {
+        HistoryDispositionRequest {
+            items,
+            prune_superseded_artifacts,
+            drop_prior_artifact_kinds: self.drop_prior_artifact_kinds.clone(),
+            legacy_compaction_marker_policy: self.legacy_compaction_marker_policy,
+        }
+    }
+
     pub(crate) fn initial_context_injection(&self) -> InitialContextInjection {
         match self.context_injection {
             ContextInjectionPolicy::None => InitialContextInjection::DoNotInject,
@@ -70,11 +84,8 @@ impl RuntimeMaintenancePlan {
         self.context_injection
     }
 
-    pub(crate) fn preserves_legacy_compaction_marker(&self) -> bool {
-        !matches!(
-            self.legacy_compaction_marker_policy,
-            LegacyCompactionMarkerPolicy::Strip
-        )
+    pub(crate) fn legacy_compaction_marker_policy(&self) -> LegacyCompactionMarkerPolicy {
+        self.legacy_compaction_marker_policy
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Summary
- move artifact dropping and legacy compaction-marker stripping behind one policy-owned disposition helper
- route refresh, prune, and remote compacted-history shaping through that unified disposition path
- preserve the full legacy compaction-marker policy enum at the runtime boundary and add route-level/tests for marker behavior

## Testing
- `cargo test -p codex-context-maintenance-policy`
- `cargo test -p codex-core compaction_policy_matrix_tests --lib`
- `cargo test -p codex-core compact::tests --lib`
- `cargo test -p codex-core context_maintenance::tests --lib`
- `cargo test -p codex-core codex_tests_guardian::process_compacted_history_preserves_separate_guardian_developer_message --lib`
- `just fix -p codex-context-maintenance-policy`
- `just fix -p codex-core`
- `just fmt`