### PR TITLE
[codex] Decouple compact timing from injection placement

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -17,12 +17,12 @@ use crate::agent_identity::AgentIdentityManager;
 use crate::apps::render_apps_section;
 use crate::commit_attribution::commit_message_trailer_instruction;
 use crate::compact;
-use crate::compact::InitialContextInjection;
 use crate::compact::run_inline_auto_compact_task;
 use crate::compact::should_use_remote_compact_task;
 use crate::compact_remote::run_inline_remote_auto_compact_task;
 use crate::config::ManagedFeatures;
 use crate::connectors;
+use crate::context_maintenance_runtime::CompactInvocationTiming;
 use crate::exec_policy::ExecPolicyManager;
 use crate::installation_id::resolve_installation_id;
 use crate::mcp_tool_exposure::build_mcp_tool_exposure;
@@ -6716,7 +6716,7 @@ pub(crate) async fn run_turn(
                     if run_auto_compact(
                         &sess,
                         &turn_context,
-                        InitialContextInjection::BeforeLastUserMessage,
+                        CompactInvocationTiming::IntraTurn,
                         CompactionReason::ContextLimit,
                         CompactionPhase::MidTurn,
                     )
@@ -6951,7 +6951,7 @@ async fn run_pre_sampling_compact(
         run_auto_compact(
             sess,
             turn_context,
-            InitialContextInjection::DoNotInject,
+            CompactInvocationTiming::TurnBoundary,
             CompactionReason::ContextLimit,
             CompactionPhase::PreTurn,
         )
@@ -6998,7 +6998,7 @@ async fn maybe_run_previous_model_inline_compact(
         run_auto_compact(
             sess,
             &previous_model_turn_context,
-            InitialContextInjection::DoNotInject,
+            CompactInvocationTiming::TurnBoundary,
             CompactionReason::ModelDownshift,
             CompactionPhase::PreTurn,
         )
@@ -7011,7 +7011,7 @@ async fn maybe_run_previous_model_inline_compact(
 async fn run_auto_compact(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    initial_context_injection: InitialContextInjection,
+    timing: CompactInvocationTiming,
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
@@ -7019,7 +7019,7 @@ async fn run_auto_compact(
         run_inline_remote_auto_compact_task(
             Arc::clone(sess),
             Arc::clone(turn_context),
-            initial_context_injection,
+            timing,
             reason,
             phase,
         )
@@ -7028,7 +7028,7 @@ async fn run_auto_compact(
         run_inline_auto_compact_task(
             Arc::clone(sess),
             Arc::clone(turn_context),
-            initial_context_injection,
+            timing,
             reason,
             phase,
         )

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -11,7 +11,7 @@ use crate::codex::TurnContext;
 use crate::codex::get_last_assistant_message_from_turn;
 use crate::config::CompactionEngine;
 use crate::context_maintenance_config::resolve_context_maintenance_request_context;
-use crate::context_maintenance_runtime::compact_timing_from_initial_context_injection;
+use crate::context_maintenance_runtime::CompactInvocationTiming;
 use crate::context_maintenance_runtime::execute_requested_artifact;
 use crate::context_maintenance_runtime::runtime_plan_for_compact;
 use crate::continuation_bridge::generate_continuation_bridge_item;
@@ -59,12 +59,11 @@ pub(crate) const COMPACT_RAW_CONVERSATION_WINDOW_MESSAGES: usize = 5;
 /// clear `reference_context_item`, so the next regular turn will fully reinject initial context
 /// after compaction.
 ///
-/// Mid-turn compaction must use `BeforeLastUserMessage` because the model is trained to see the
-/// compaction summary as the last item in history after mid-turn compaction; we therefore inject
-/// initial context into the replacement history just above the last real user message.
+/// Mid-turn compaction injects initial context above the last real user message or summary because
+/// the model is trained to see the compaction summary as the last item in replacement history.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum InitialContextInjection {
-    BeforeLastUserMessage,
+    BeforeLastRealUserOrSummary,
     DoNotInject,
 }
 
@@ -78,7 +77,7 @@ pub(crate) fn should_use_remote_compact_task(turn_context: &TurnContext) -> bool
 pub(crate) async fn run_inline_auto_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
-    initial_context_injection: InitialContextInjection,
+    timing: CompactInvocationTiming,
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
@@ -93,7 +92,7 @@ pub(crate) async fn run_inline_auto_compact_task(
         sess,
         turn_context,
         input,
-        initial_context_injection,
+        timing,
         CompactionTrigger::Auto,
         reason,
         phase,
@@ -118,7 +117,7 @@ pub(crate) async fn run_compact_task(
         sess.clone(),
         turn_context,
         input,
-        InitialContextInjection::DoNotInject,
+        CompactInvocationTiming::TurnBoundary,
         CompactionTrigger::Manual,
         CompactionReason::UserRequested,
         CompactionPhase::StandaloneTurn,
@@ -130,7 +129,7 @@ async fn run_compact_task_inner(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
     input: Vec<UserInput>,
-    initial_context_injection: InitialContextInjection,
+    timing: CompactInvocationTiming,
     trigger: CompactionTrigger,
     reason: CompactionReason,
     phase: CompactionPhase,
@@ -144,13 +143,9 @@ async fn run_compact_task_inner(
         phase,
     )
     .await;
-    let result = run_compact_task_inner_impl(
-        Arc::clone(&sess),
-        Arc::clone(&turn_context),
-        input,
-        initial_context_injection,
-    )
-    .await;
+    let result =
+        run_compact_task_inner_impl(Arc::clone(&sess), Arc::clone(&turn_context), input, timing)
+            .await;
     attempt
         .track(
             sess.as_ref(),
@@ -165,11 +160,10 @@ async fn run_compact_task_inner_impl(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
     input: Vec<UserInput>,
-    initial_context_injection: InitialContextInjection,
+    timing: CompactInvocationTiming,
 ) -> CodexResult<()> {
-    let timing = compact_timing_from_initial_context_injection(initial_context_injection);
     let runtime_plan = runtime_plan_for_compact(turn_context.as_ref(), timing)?;
-    let initial_context_injection = runtime_plan.initial_context_injection();
+    let initial_context_injection = runtime_plan.context_injection_placement();
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(&turn_context, &compaction_item)
         .await;
@@ -322,7 +316,7 @@ async fn run_compact_task_inner_impl(
 
     if matches!(
         initial_context_injection,
-        InitialContextInjection::BeforeLastUserMessage
+        InitialContextInjection::BeforeLastRealUserOrSummary
     ) {
         let initial_context = sess.build_initial_context(turn_context.as_ref()).await;
         new_history =
@@ -346,7 +340,9 @@ async fn run_compact_task_inner_impl(
     new_history.extend(ghost_snapshots);
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
-        InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
+        InitialContextInjection::BeforeLastRealUserOrSummary => {
+            Some(turn_context.to_turn_context_item())
+        }
     };
     let compacted_item = CompactedItem {
         message: summary_text.clone(),

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -163,7 +163,7 @@ async fn run_compact_task_inner_impl(
     timing: CompactInvocationTiming,
 ) -> CodexResult<()> {
     let runtime_plan = runtime_plan_for_compact(turn_context.as_ref(), timing)?;
-    let initial_context_injection = runtime_plan.context_injection_placement();
+    let injection_placement = runtime_plan.context_injection_placement();
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(&turn_context, &compaction_item)
         .await;
@@ -315,7 +315,7 @@ async fn run_compact_task_inner_impl(
     let mut new_history = build_compacted_history(Vec::new(), &user_messages, &summary_text);
 
     if matches!(
-        initial_context_injection,
+        injection_placement,
         InitialContextInjection::BeforeLastRealUserOrSummary
     ) {
         let initial_context = sess.build_initial_context(turn_context.as_ref()).await;
@@ -338,7 +338,7 @@ async fn run_compact_task_inner_impl(
         .cloned()
         .collect();
     new_history.extend(ghost_snapshots);
-    let reference_context_item = match initial_context_injection {
+    let reference_context_item = match injection_placement {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastRealUserOrSummary => {
             Some(turn_context.to_turn_context_item())

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -12,7 +12,7 @@ use crate::compact::compaction_status_from_result;
 use crate::compact::is_raw_conversation_message;
 use crate::compact::is_real_user_message;
 use crate::compact::is_user_or_summary_message;
-use crate::context_maintenance_runtime::compact_timing_from_initial_context_injection;
+use crate::context_maintenance_runtime::CompactInvocationTiming;
 use crate::context_maintenance_runtime::execute_requested_artifact;
 use crate::context_maintenance_runtime::runtime_plan_for_compact;
 use crate::context_manager::ContextManager;
@@ -56,14 +56,14 @@ pub(crate) struct ProcessCompactedHistoryRequest {
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
-    initial_context_injection: InitialContextInjection,
+    timing: CompactInvocationTiming,
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
     run_remote_compact_task_inner(
         &sess,
         &turn_context,
-        initial_context_injection,
+        timing,
         CompactionTrigger::Auto,
         reason,
         phase,
@@ -87,7 +87,7 @@ pub(crate) async fn run_remote_compact_task(
     run_remote_compact_task_inner(
         &sess,
         &turn_context,
-        InitialContextInjection::DoNotInject,
+        CompactInvocationTiming::TurnBoundary,
         CompactionTrigger::Manual,
         CompactionReason::UserRequested,
         CompactionPhase::StandaloneTurn,
@@ -98,7 +98,7 @@ pub(crate) async fn run_remote_compact_task(
 async fn run_remote_compact_task_inner(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    initial_context_injection: InitialContextInjection,
+    timing: CompactInvocationTiming,
     trigger: CompactionTrigger,
     reason: CompactionReason,
     phase: CompactionPhase,
@@ -112,8 +112,7 @@ async fn run_remote_compact_task_inner(
         phase,
     )
     .await;
-    let result =
-        run_remote_compact_task_inner_impl(sess, turn_context, initial_context_injection).await;
+    let result = run_remote_compact_task_inner_impl(sess, turn_context, timing).await;
     attempt
         .track(
             sess.as_ref(),
@@ -134,11 +133,10 @@ async fn run_remote_compact_task_inner(
 async fn run_remote_compact_task_inner_impl(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    initial_context_injection: InitialContextInjection,
+    timing: CompactInvocationTiming,
 ) -> CodexResult<()> {
-    let timing = compact_timing_from_initial_context_injection(initial_context_injection);
     let runtime_plan = runtime_plan_for_compact(turn_context.as_ref(), timing)?;
-    let initial_context_injection = runtime_plan.initial_context_injection();
+    let initial_context_injection = runtime_plan.context_injection_placement();
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(turn_context, &compaction_item)
         .await;
@@ -250,7 +248,9 @@ async fn run_remote_compact_task_inner_impl(
     }
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
-        InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
+        InitialContextInjection::BeforeLastRealUserOrSummary => {
+            Some(turn_context.to_turn_context_item())
+        }
     };
     let compacted_item = CompactedItem {
         message: String::new(),

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -136,7 +136,7 @@ async fn run_remote_compact_task_inner_impl(
     timing: CompactInvocationTiming,
 ) -> CodexResult<()> {
     let runtime_plan = runtime_plan_for_compact(turn_context.as_ref(), timing)?;
-    let initial_context_injection = runtime_plan.context_injection_placement();
+    let injection_placement = runtime_plan.context_injection_placement();
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(turn_context, &compaction_item)
         .await;
@@ -246,7 +246,7 @@ async fn run_remote_compact_task_inner_impl(
     if !ghost_snapshots.is_empty() {
         new_history.extend(ghost_snapshots);
     }
-    let reference_context_item = match initial_context_injection {
+    let reference_context_item = match injection_placement {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastRealUserOrSummary => {
             Some(turn_context.to_turn_context_item())

--- a/codex-rs/core/src/compaction_policy_matrix_tests.rs
+++ b/codex-rs/core/src/compaction_policy_matrix_tests.rs
@@ -1,6 +1,6 @@
 use crate::config::CompactionEngine;
 use crate::config::GovernancePathVariant;
-use crate::context_maintenance_runtime::CompactTimingForTests;
+use crate::context_maintenance_runtime::CompactInvocationTiming;
 use crate::context_maintenance_runtime::TurnBoundaryMaintenanceActionForTests;
 use crate::context_maintenance_runtime::live_compact_route_behavior_for_tests;
 use crate::context_maintenance_runtime::live_turn_boundary_maintenance_behavior_for_tests;
@@ -16,7 +16,7 @@ fn live_local_pure_intra_turn_compact_is_bridge_only() {
     let behavior = live_compact_route_behavior_for_tests(
         CompactionEngine::LocalPure,
         GovernancePathVariant::StrictV1Shadow,
-        CompactTimingForTests::IntraTurn,
+        CompactInvocationTiming::IntraTurn,
     );
 
     assert_eq!(
@@ -46,7 +46,7 @@ fn live_remote_hybrid_turn_boundary_compact_is_thread_memory_only() {
     let behavior = live_compact_route_behavior_for_tests(
         CompactionEngine::RemoteHybrid,
         GovernancePathVariant::StrictV1Shadow,
-        CompactTimingForTests::TurnBoundary,
+        CompactInvocationTiming::TurnBoundary,
     );
 
     assert_eq!(behavior.requests_artifact(ArtifactKind::ThreadMemory), true);
@@ -77,7 +77,7 @@ fn live_turn_boundary_compact_suppresses_thread_memory_when_governance_is_off() 
     let behavior = live_compact_route_behavior_for_tests(
         CompactionEngine::LocalPure,
         GovernancePathVariant::Off,
-        CompactTimingForTests::TurnBoundary,
+        CompactInvocationTiming::TurnBoundary,
     );
 
     assert_eq!(

--- a/codex-rs/core/src/context_maintenance_runtime.rs
+++ b/codex-rs/core/src/context_maintenance_runtime.rs
@@ -71,11 +71,11 @@ impl RuntimeMaintenancePlan {
         }
     }
 
-    pub(crate) fn initial_context_injection(&self) -> InitialContextInjection {
+    pub(crate) fn context_injection_placement(&self) -> InitialContextInjection {
         match self.context_injection {
             ContextInjectionPolicy::None => InitialContextInjection::DoNotInject,
             ContextInjectionPolicy::BeforeLastRealUserOrSummary => {
-                InitialContextInjection::BeforeLastUserMessage
+                InitialContextInjection::BeforeLastRealUserOrSummary
             }
         }
     }
@@ -133,25 +133,30 @@ fn required_artifact_error_detail(err: CodexErr) -> String {
     }
 }
 
-#[cfg(test)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum CompactTimingForTests {
+pub(crate) enum CompactInvocationTiming {
     TurnBoundary,
     IntraTurn,
+}
+
+impl CompactInvocationTiming {
+    fn maintenance_timing(self) -> MaintenanceTiming {
+        match self {
+            Self::TurnBoundary => MaintenanceTiming::TurnBoundary,
+            Self::IntraTurn => MaintenanceTiming::IntraTurn,
+        }
+    }
 }
 
 #[cfg(test)]
 pub(crate) fn live_compact_route_behavior_for_tests(
     engine: CompactionEngine,
     governance_variant: GovernancePathVariant,
-    timing: CompactTimingForTests,
+    timing: CompactInvocationTiming,
 ) -> RuntimeMaintenancePlan {
     runtime_plan(MaintenancePlanningRequest {
         action: MaintenanceAction::Compact,
-        timing: match timing {
-            CompactTimingForTests::TurnBoundary => MaintenanceTiming::TurnBoundary,
-            CompactTimingForTests::IntraTurn => MaintenanceTiming::IntraTurn,
-        },
+        timing: timing.maintenance_timing(),
         engine: policy_engine(engine),
         thread_memory_governance: policy_thread_memory_governance(governance_variant),
     })
@@ -194,11 +199,11 @@ pub(crate) fn try_live_turn_boundary_maintenance_behavior_for_tests(
 
 pub(crate) fn runtime_plan_for_compact(
     turn_context: &TurnContext,
-    timing: MaintenanceTiming,
+    timing: CompactInvocationTiming,
 ) -> CodexResult<RuntimeMaintenancePlan> {
     runtime_plan(MaintenancePlanningRequest {
         action: MaintenanceAction::Compact,
-        timing,
+        timing: timing.maintenance_timing(),
         engine: policy_engine(compaction_engine(turn_context)),
         thread_memory_governance: policy_thread_memory_governance(
             turn_context.governance_path_variant(),
@@ -218,15 +223,6 @@ pub(crate) fn runtime_plan_for_turn_boundary_maintenance(
             turn_context.governance_path_variant(),
         ),
     })
-}
-
-pub(crate) fn compact_timing_from_initial_context_injection(
-    initial_context_injection: InitialContextInjection,
-) -> MaintenanceTiming {
-    match initial_context_injection {
-        InitialContextInjection::DoNotInject => MaintenanceTiming::TurnBoundary,
-        InitialContextInjection::BeforeLastUserMessage => MaintenanceTiming::IntraTurn,
-    }
 }
 
 pub(crate) fn compaction_engine(turn_context: &TurnContext) -> CompactionEngine {
@@ -340,6 +336,41 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "Fatal error: failed generating required continuation bridge during test: boom"
+        );
+    }
+
+    #[test]
+    fn compact_invocation_timing_maps_to_maintenance_timing() {
+        assert_eq!(
+            CompactInvocationTiming::TurnBoundary.maintenance_timing(),
+            MaintenanceTiming::TurnBoundary
+        );
+        assert_eq!(
+            CompactInvocationTiming::IntraTurn.maintenance_timing(),
+            MaintenanceTiming::IntraTurn
+        );
+    }
+
+    #[test]
+    fn compact_timing_drives_context_injection_placement() {
+        let turn_boundary = live_compact_route_behavior_for_tests(
+            CompactionEngine::LocalPure,
+            GovernancePathVariant::StrictV1Shadow,
+            CompactInvocationTiming::TurnBoundary,
+        );
+        let intra_turn = live_compact_route_behavior_for_tests(
+            CompactionEngine::LocalPure,
+            GovernancePathVariant::StrictV1Shadow,
+            CompactInvocationTiming::IntraTurn,
+        );
+
+        assert_eq!(
+            turn_boundary.context_injection_placement(),
+            InitialContextInjection::DoNotInject
+        );
+        assert_eq!(
+            intra_turn.context_injection_placement(),
+            InitialContextInjection::BeforeLastRealUserOrSummary
         );
     }
 }


### PR DESCRIPTION
## Summary
- classify compact timing explicitly at the runtime call boundary instead of deriving it from injection placement
- rename the core injection variant to match the actual policy meaning: last real user or summary
- add runtime tests for timing classification and timing-to-injection placement

## Testing
- cargo test -p codex-core context_maintenance_runtime::tests --lib
- cargo test -p codex-core compaction_policy_matrix_tests --lib
- cargo test -p codex-core compact::tests --lib
- cargo test -p codex-core context_maintenance::tests --lib
- just fix -p codex-core
- just fmt
