### PR TITLE
[codex] Tighten policy exports and cleanup route errors

### DIFF
--- a/codex-rs/context-maintenance-policy/src/artifact_codecs.rs
+++ b/codex-rs/context-maintenance-policy/src/artifact_codecs.rs
@@ -97,7 +97,8 @@ fn is_close_tag_boundary(after_tag: &str) -> bool {
     matches!(after_tag.chars().next(), Some('>'))
 }
 
-pub fn remove_artifact_kind(
+#[cfg(test)]
+pub(crate) fn remove_artifact_kind(
     items: Vec<ResponseItem>,
     kind: ArtifactKind,
 ) -> (Vec<ResponseItem>, usize) {
@@ -116,7 +117,7 @@ pub fn remove_artifact_kind(
     (items, removed)
 }
 
-pub fn prune_superseded_artifacts(items: Vec<ResponseItem>) -> (Vec<ResponseItem>, usize) {
+pub(crate) fn prune_superseded_artifacts(items: Vec<ResponseItem>) -> (Vec<ResponseItem>, usize) {
     let mut last_continuation_bridge = None;
     let mut last_thread_memory = None;
     let mut last_prune_manifest = None;

--- a/codex-rs/context-maintenance-policy/src/contracts.rs
+++ b/codex-rs/context-maintenance-policy/src/contracts.rs
@@ -139,9 +139,7 @@ pub struct MaintenancePolicyPlan {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Error)]
 pub enum MaintenancePolicyError {
-    #[error(
-        "unsupported context-maintenance route: action={action:?} timing={timing:?} engine={engine:?}"
-    )]
+    #[error("action={action:?} timing={timing:?} engine={engine:?}")]
     UnsupportedRoute {
         action: MaintenanceAction,
         timing: MaintenanceTiming,

--- a/codex-rs/context-maintenance-policy/src/contracts.rs
+++ b/codex-rs/context-maintenance-policy/src/contracts.rs
@@ -139,7 +139,7 @@ pub struct MaintenancePolicyPlan {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Error)]
 pub enum MaintenancePolicyError {
-    #[error("action={action:?} timing={timing:?} engine={engine:?}")]
+    #[error("action={action:?}, timing={timing:?}, engine={engine:?}")]
     UnsupportedRoute {
         action: MaintenanceAction,
         timing: MaintenanceTiming,

--- a/codex-rs/context-maintenance-policy/src/lib.rs
+++ b/codex-rs/context-maintenance-policy/src/lib.rs
@@ -9,8 +9,6 @@ mod thread_memory;
 pub use artifact_codecs::apply_history_disposition;
 pub use artifact_codecs::apply_history_disposition_with_summary_classifier;
 pub use artifact_codecs::build_prune_manifest_item;
-pub use artifact_codecs::prune_superseded_artifacts;
-pub use artifact_codecs::remove_artifact_kind;
 pub use continuation_bridge::BridgeVariant;
 pub use continuation_bridge::ContinuationBridgeModelInput;
 pub use continuation_bridge::ContinuationBridgePayload;

--- a/codex-rs/core/src/compaction_policy_matrix_tests.rs
+++ b/codex-rs/core/src/compaction_policy_matrix_tests.rs
@@ -166,7 +166,7 @@ fn live_remote_vanilla_refresh_fails_closed() {
 
     assert_eq!(
         err.to_string(),
-        "Fatal error: Unsupported context-maintenance route: unsupported context-maintenance route: action=Refresh timing=TurnBoundary engine=RemoteVanilla"
+        "Fatal error: Unsupported context-maintenance route: action=Refresh timing=TurnBoundary engine=RemoteVanilla"
     );
 }
 

--- a/codex-rs/core/src/compaction_policy_matrix_tests.rs
+++ b/codex-rs/core/src/compaction_policy_matrix_tests.rs
@@ -166,7 +166,7 @@ fn live_remote_vanilla_refresh_fails_closed() {
 
     assert_eq!(
         err.to_string(),
-        "Fatal error: Unsupported context-maintenance route: action=Refresh timing=TurnBoundary engine=RemoteVanilla"
+        "Fatal error: Unsupported context-maintenance route: action=Refresh, timing=TurnBoundary, engine=RemoteVanilla"
     );
 }
 


### PR DESCRIPTION
## Summary
- drop internal-only policy-crate exports that no longer serve the cross-crate seam
- make the helper-only `remove_artifact_kind` test-only inside the policy crate
- normalize unsupported-route wording so runtime errors no longer duplicate the same prefix

## Testing
- cargo test -p codex-context-maintenance-policy
- cargo test -p codex-core compaction_policy_matrix_tests --lib
- just fix -p codex-context-maintenance-policy
- just fix -p codex-core
- just fmt

## Notes
- I did not run the full `cargo test` suite because repo instructions require asking first before a complete `codex-core` run.
