### PR TITLE
[codex] Extract agent observability reducer and lock behavior

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1367,6 +1367,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-agent-observability"
+version = "0.121.0"
+dependencies = [
+ "codex-protocol",
+ "codex-utils-absolute-path",
+ "pretty_assertions",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "codex-analytics"
 version = "0.121.0"
 dependencies = [
@@ -1916,6 +1927,7 @@ dependencies = [
  "bm25",
  "chrono",
  "clap",
+ "codex-agent-observability",
  "codex-analytics",
  "codex-api",
  "codex-app-server-protocol",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "analytics",
+    "agent-observability",
     "backend-client",
     "ansi-escape",
     "async-utils",
@@ -106,6 +107,7 @@ license = "Apache-2.0"
 [workspace.dependencies]
 # Internal
 app_test_support = { path = "app-server/tests/common" }
+codex-agent-observability = { path = "agent-observability" }
 codex-analytics = { path = "analytics" }
 codex-ansi-escape = { path = "ansi-escape" }
 codex-api = { path = "codex-api" }

--- a/codex-rs/agent-observability/BUILD.bazel
+++ b/codex-rs/agent-observability/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//:defs.bzl", "codex_rust_crate")
+
+codex_rust_crate(
+    name = "agent-observability",
+    crate_name = "codex_agent_observability",
+)

--- a/codex-rs/agent-observability/Cargo.toml
+++ b/codex-rs/agent-observability/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "codex-agent-observability"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+codex-protocol = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+
+[dev-dependencies]
+codex-utils-absolute-path = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/codex-rs/agent-observability/src/lib.rs
+++ b/codex-rs/agent-observability/src/lib.rs
@@ -1,0 +1,10 @@
+//! Semantic owner for agent progress observation and reduction.
+
+mod progress;
+
+pub use progress::AgentActiveWork;
+pub use progress::AgentActiveWorkKind;
+pub use progress::AgentBlockReason;
+pub use progress::AgentProgressPhase;
+pub use progress::AgentProgressSnapshot;
+pub use progress::ProgressRegistry;

--- a/codex-rs/agent-observability/src/progress.rs
+++ b/codex-rs/agent-observability/src/progress.rs
@@ -624,10 +624,7 @@ fn phase_for_status(status: &AgentStatus) -> Option<AgentProgressPhase> {
 }
 
 fn is_final_for_progress(status: &AgentStatus) -> bool {
-    !matches!(
-        status,
-        AgentStatus::PendingInit | AgentStatus::Running | AgentStatus::Interrupted
-    )
+    !matches!(status, AgentStatus::PendingInit | AgentStatus::Running)
 }
 
 fn push_update(snapshot: &mut LiveProgressSnapshot, update: String) {
@@ -930,6 +927,7 @@ mod tests {
             registry.inspect(thread_id, AgentStatus::Interrupted, Duration::from_secs(1));
         assert_eq!(interrupted.phase, AgentProgressPhase::Interrupted);
         assert_eq!(interrupted.active_work, None);
+        assert_eq!(interrupted.stalled, false);
     }
 
     #[tokio::test]

--- a/codex-rs/agent-observability/src/progress.rs
+++ b/codex-rs/agent-observability/src/progress.rs
@@ -1,7 +1,6 @@
-use crate::agent::AgentStatus;
-use crate::agent::status::is_final;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::AgentReasoningEvent;
+use codex_protocol::protocol::AgentStatus;
 use codex_protocol::protocol::EventMsg;
 use serde::Deserialize;
 use serde::Serialize;
@@ -17,7 +16,7 @@ const MAX_PREVIEW_CHARS: usize = 160;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum AgentProgressPhase {
+pub enum AgentProgressPhase {
     Pending,
     Reasoning,
     MessageDrafting,
@@ -33,7 +32,7 @@ pub(crate) enum AgentProgressPhase {
 
 #[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum AgentBlockReason {
+pub enum AgentBlockReason {
     ExecApproval,
     PatchApproval,
     PermissionsRequest,
@@ -43,7 +42,7 @@ pub(crate) enum AgentBlockReason {
 
 #[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum AgentActiveWorkKind {
+pub enum AgentActiveWorkKind {
     Reasoning,
     Message,
     Command,
@@ -51,26 +50,46 @@ pub(crate) enum AgentActiveWorkKind {
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
-pub(crate) struct AgentActiveWork {
-    kind: AgentActiveWorkKind,
-    label: String,
+pub struct AgentActiveWork {
+    pub kind: AgentActiveWorkKind,
+    pub label: String,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
-pub(crate) struct AgentProgressSnapshot {
-    pub(crate) lifecycle_status: AgentStatus,
-    pub(crate) phase: AgentProgressPhase,
-    pub(crate) blocked_on: Option<AgentBlockReason>,
-    pub(crate) active_work: Option<AgentActiveWork>,
-    pub(crate) recent_updates: Vec<String>,
-    pub(crate) latest_visible_message: Option<String>,
-    pub(crate) final_message: Option<String>,
-    pub(crate) error_message: Option<String>,
-    pub(crate) ever_entered_turn: bool,
-    pub(crate) ever_reported_progress: bool,
-    pub(crate) last_progress_age_ms: Option<u64>,
-    pub(crate) seq: u64,
-    pub(crate) stalled: bool,
+pub struct AgentProgressSnapshot {
+    pub lifecycle_status: AgentStatus,
+    pub phase: AgentProgressPhase,
+    pub blocked_on: Option<AgentBlockReason>,
+    pub active_work: Option<AgentActiveWork>,
+    pub recent_updates: Vec<String>,
+    pub latest_visible_message: Option<String>,
+    pub final_message: Option<String>,
+    pub error_message: Option<String>,
+    pub ever_entered_turn: bool,
+    pub ever_reported_progress: bool,
+    pub last_progress_age_ms: Option<u64>,
+    pub seq: u64,
+    pub stalled: bool,
+}
+
+impl AgentProgressSnapshot {
+    pub fn not_found() -> Self {
+        Self {
+            lifecycle_status: AgentStatus::NotFound,
+            phase: AgentProgressPhase::Pending,
+            blocked_on: None,
+            active_work: None,
+            recent_updates: Vec::new(),
+            latest_visible_message: None,
+            final_message: None,
+            error_message: None,
+            ever_entered_turn: false,
+            ever_reported_progress: false,
+            last_progress_age_ms: None,
+            seq: 0,
+            stalled: false,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -140,13 +159,14 @@ impl TrackedProgressState {
     }
 }
 
+/// Reduces emitted protocol events into per-thread progress snapshots.
 #[derive(Default)]
-pub(crate) struct ProgressRegistry {
+pub struct ProgressRegistry {
     by_thread: Mutex<HashMap<ThreadId, TrackedProgressState>>,
 }
 
 impl ProgressRegistry {
-    pub(crate) fn seed(&self, thread_id: ThreadId) {
+    pub fn seed(&self, thread_id: ThreadId) {
         let mut snapshots = self
             .by_thread
             .lock()
@@ -157,7 +177,7 @@ impl ProgressRegistry {
             .or_insert_with(|| TrackedProgressState::seeded(now));
     }
 
-    pub(crate) fn subscribe_seq(&self, thread_id: ThreadId) -> watch::Receiver<u64> {
+    pub fn subscribe_seq(&self, thread_id: ThreadId) -> watch::Receiver<u64> {
         let mut snapshots = self
             .by_thread
             .lock()
@@ -170,7 +190,7 @@ impl ProgressRegistry {
             .subscribe()
     }
 
-    pub(crate) fn record_event(&self, thread_id: ThreadId, event: &EventMsg) {
+    pub fn record_event(&self, thread_id: ThreadId, event: &EventMsg) {
         let mut snapshots = self
             .by_thread
             .lock()
@@ -501,7 +521,7 @@ impl ProgressRegistry {
         }
     }
 
-    pub(crate) fn inspect(
+    pub fn inspect(
         &self,
         thread_id: ThreadId,
         lifecycle_status: AgentStatus,
@@ -517,7 +537,7 @@ impl ProgressRegistry {
         let last_progress_age_ms = snapshot
             .last_progress_at
             .map(|instant| duration_millis_u64(instant.elapsed()));
-        let stalled = !is_final(&lifecycle_status)
+        let stalled = !is_final_for_progress(&lifecycle_status)
             && snapshot.blocked_on.is_none()
             && duration_millis_u64(
                 snapshot
@@ -565,7 +585,7 @@ impl ProgressRegistry {
         resolved
     }
 
-    pub(crate) fn remove(&self, thread_id: &ThreadId) {
+    pub fn remove(&self, thread_id: &ThreadId) {
         self.by_thread
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -601,6 +621,13 @@ fn phase_for_status(status: &AgentStatus) -> Option<AgentProgressPhase> {
         AgentStatus::Shutdown => Some(AgentProgressPhase::Shutdown),
         AgentStatus::Running | AgentStatus::NotFound => None,
     }
+}
+
+fn is_final_for_progress(status: &AgentStatus) -> bool {
+    !matches!(
+        status,
+        AgentStatus::PendingInit | AgentStatus::Running | AgentStatus::Interrupted
+    )
 }
 
 fn push_update(snapshot: &mut LiveProgressSnapshot, update: String) {

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -25,6 +25,7 @@ base64 = { workspace = true }
 bm25 = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive"] }
+codex-agent-observability = { workspace = true }
 codex-analytics = { workspace = true }
 codex-api = { workspace = true }
 codex-app-server-protocol = { workspace = true }

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -1,6 +1,4 @@
 use crate::agent::AgentStatus;
-use crate::agent::progress::AgentProgressPhase;
-use crate::agent::progress::AgentProgressSnapshot;
 use crate::agent::registry::AgentMetadata;
 use crate::agent::registry::AgentRegistry;
 use crate::agent::role::DEFAULT_ROLE_NAME;
@@ -16,6 +14,7 @@ use crate::session_prefix::format_subagent_notification_message;
 use crate::shell_snapshot::ShellSnapshot;
 use crate::thread_manager::ThreadManagerState;
 use crate::thread_rollout_truncation::truncate_rollout_to_last_n_fork_turns;
+use codex_agent_observability::AgentProgressSnapshot;
 use codex_features::Feature;
 use codex_protocol::AgentPath;
 use codex_protocol::ThreadId;
@@ -836,21 +835,7 @@ impl AgentControl {
         stalled_after: Duration,
     ) -> AgentProgressSnapshot {
         let Ok(state) = self.upgrade() else {
-            return AgentProgressSnapshot {
-                lifecycle_status: AgentStatus::NotFound,
-                phase: AgentProgressPhase::Pending,
-                blocked_on: None,
-                active_work: None,
-                recent_updates: Vec::new(),
-                latest_visible_message: None,
-                final_message: None,
-                error_message: None,
-                ever_entered_turn: false,
-                ever_reported_progress: false,
-                last_progress_age_ms: None,
-                seq: 0,
-                stalled: false,
-            };
+            return AgentProgressSnapshot::not_found();
         };
         let lifecycle_status = match state.get_thread(agent_id).await {
             Ok(thread) => thread.agent_status().await,

--- a/codex-rs/core/src/agent/mod.rs
+++ b/codex-rs/core/src/agent/mod.rs
@@ -1,7 +1,6 @@
 pub(crate) mod agent_resolver;
 pub(crate) mod control;
 pub(crate) mod mailbox;
-pub(crate) mod progress;
 mod registry;
 pub(crate) mod role;
 pub(crate) mod status;

--- a/codex-rs/core/src/agent/progress.rs
+++ b/codex-rs/core/src/agent/progress.rs
@@ -709,6 +709,7 @@ mod tests {
     use codex_protocol::protocol::ExecCommandOutputDeltaEvent;
     use codex_protocol::protocol::ExecCommandStatus;
     use codex_protocol::protocol::ExecOutputStream;
+    use codex_protocol::protocol::StreamErrorEvent;
     use codex_protocol::protocol::TurnAbortReason;
     use codex_protocol::protocol::TurnAbortedEvent;
     use codex_protocol::protocol::TurnCompleteEvent;
@@ -940,6 +941,20 @@ mod tests {
 
         registry.record_event(
             thread_id,
+            &EventMsg::StreamError(StreamErrorEvent {
+                message: "temporary disconnect".to_string(),
+                codex_error_info: None,
+                additional_details: None,
+            }),
+        );
+        assert!(
+            timeout(Duration::from_millis(20), seq_rx.changed())
+                .await
+                .is_err()
+        );
+
+        registry.record_event(
+            thread_id,
             &EventMsg::AgentReasoning(AgentReasoningEvent {
                 text: "scanning repo".to_string(),
             }),
@@ -949,6 +964,18 @@ mod tests {
             .await
             .expect("material progress should wake watchers");
         assert_eq!(*seq_rx.borrow(), 1);
+
+        registry.record_event(
+            thread_id,
+            &EventMsg::AgentReasoningDelta(codex_protocol::protocol::AgentReasoningDeltaEvent {
+                delta: " and cataloging modules".to_string(),
+            }),
+        );
+        assert!(
+            timeout(Duration::from_millis(20), seq_rx.changed())
+                .await
+                .is_err()
+        );
 
         registry.record_event(
             thread_id,
@@ -1027,8 +1054,8 @@ mod tests {
         assert_eq!(
             ended.recent_updates,
             vec![
-                "turn started".to_string(),
                 "warning: still initializing".to_string(),
+                "stream error: temporary disconnect".to_string(),
                 "reasoning: scanning repo".to_string(),
                 "running command: rg --files".to_string(),
                 "command finished: rg --files".to_string(),

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -1,6 +1,5 @@
 use crate::SkillsManager;
 use crate::agent::AgentControl;
-use crate::agent::progress::ProgressRegistry;
 use crate::codex::Codex;
 use crate::codex::CodexSpawnArgs;
 use crate::codex::CodexSpawnOk;
@@ -16,6 +15,7 @@ use crate::shell_snapshot::ShellSnapshot;
 use crate::skills_watcher::SkillsWatcher;
 use crate::skills_watcher::SkillsWatcherEvent;
 use crate::tasks::interrupted_turn_history_marker;
+use codex_agent_observability::ProgressRegistry;
 use codex_analytics::AnalyticsEventsClient;
 use codex_app_server_protocol::ThreadHistoryBuilder;
 use codex_app_server_protocol::TurnStatus;

--- a/codex-rs/core/src/tools/handlers/agent_progress.rs
+++ b/codex-rs/core/src/tools/handlers/agent_progress.rs
@@ -1,6 +1,4 @@
 use crate::agent::agent_resolver::resolve_agent_target;
-use crate::agent::progress::AgentProgressPhase;
-use crate::agent::progress::AgentProgressSnapshot;
 use crate::function_tool::FunctionCallError;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
@@ -16,6 +14,8 @@ use crate::tools::handlers::multi_agents_common::tool_output_response_item;
 use crate::tools::handlers::parse_arguments;
 use crate::tools::registry::ToolHandler;
 use crate::tools::registry::ToolKind;
+use codex_agent_observability::AgentProgressPhase;
+use codex_agent_observability::AgentProgressSnapshot;
 use codex_protocol::ThreadId;
 use codex_protocol::models::ResponseInputItem;
 use serde::Deserialize;

--- a/codex-rs/core/src/tools/handlers/agent_progress.rs
+++ b/codex-rs/core/src/tools/handlers/agent_progress.rs
@@ -393,3 +393,67 @@ fn classify_wait_match(
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_protocol::protocol::AgentStatus;
+    use pretty_assertions::assert_eq;
+
+    fn snapshot(seq: u64, phase: AgentProgressPhase) -> AgentProgressSnapshot {
+        AgentProgressSnapshot {
+            lifecycle_status: AgentStatus::Running,
+            phase,
+            blocked_on: None,
+            active_work: None,
+            recent_updates: Vec::new(),
+            latest_visible_message: None,
+            final_message: None,
+            error_message: None,
+            ever_entered_turn: true,
+            ever_reported_progress: true,
+            last_progress_age_ms: Some(10),
+            seq,
+            stalled: false,
+        }
+    }
+
+    #[test]
+    fn classify_wait_match_prefers_seq_advanced_over_phase_match() {
+        let snapshot = snapshot(2, AgentProgressPhase::WaitingApproval);
+
+        assert_eq!(
+            classify_wait_match(&snapshot, 1, &[AgentProgressPhase::WaitingApproval]),
+            Some(WaitForAgentProgressMatchReason::SeqAdvanced)
+        );
+    }
+
+    #[test]
+    fn classify_wait_match_returns_phase_matched_without_seq_advance() {
+        let snapshot = snapshot(3, AgentProgressPhase::WaitingUserInput);
+
+        assert_eq!(
+            classify_wait_match(&snapshot, 3, &[AgentProgressPhase::WaitingUserInput]),
+            Some(WaitForAgentProgressMatchReason::PhaseMatched)
+        );
+    }
+
+    #[test]
+    fn timed_out_wait_result_is_marked_as_timed_out() {
+        let result = WaitForAgentProgressResult::timed_out(
+            CanonicalAgentTarget {
+                thread_id: "thread-1".to_string(),
+                task_name: "/root/worker".to_string(),
+                nickname: Some("worker".to_string()),
+            },
+            snapshot(0, AgentProgressPhase::Pending),
+        );
+
+        assert_eq!(result.timed_out, true);
+        assert_eq!(
+            result.match_reason,
+            WaitForAgentProgressMatchReason::TimedOut
+        );
+        assert_eq!(result.message, "Wait for agent progress timed out.");
+    }
+}

--- a/codex-rs/tools/src/agent_progress_tool.rs
+++ b/codex-rs/tools/src/agent_progress_tool.rs
@@ -365,6 +365,21 @@ mod tests {
             phase_enum_schema()
         );
         assert_eq!(
+            output_schema["properties"]["blocked_on"]["enum"],
+            json!([
+                "exec_approval",
+                "patch_approval",
+                "permissions_request",
+                "user_input_request",
+                "elicitation_request",
+                null
+            ])
+        );
+        assert_eq!(
+            output_schema["properties"]["active_work"]["properties"]["kind"]["enum"],
+            json!(["reasoning", "message", "command", "tool"])
+        );
+        assert_eq!(
             output_schema["properties"]["ever_reported_progress"]["type"],
             json!("boolean")
         );


### PR DESCRIPTION
## Summary
- add A0 behavior locks for E-witness progress semantics and schema coverage
- create `codex-agent-observability` and move the live progress reducer/registry there
- update `codex-core` to consume the new crate as the semantic owner without leaving a core-owned reducer behind

## Validation
- `cargo test -p codex-agent-observability`
- `cargo test -p codex-core tools::handlers::agent_progress::tests --lib`
- `cargo test -p codex-core inspect_agent_progress_reports_reasoning_phase_for_live_subagent --lib`
- `cargo test -p codex-core wait_for_agent_progress_returns_on_material_progress --lib`
- `cargo test -p codex-tools agent_progress_tool --lib`
- `just fix -p codex-agent-observability`
- `just fix -p codex-core`
- `just fmt`