### PR TITLE
[codex] Move wait semantics into agent observability

### DIFF
--- a/codex-rs/agent-observability/src/lib.rs
+++ b/codex-rs/agent-observability/src/lib.rs
@@ -1,6 +1,7 @@
 //! Semantic owner for agent progress observation and reduction.
 
 mod progress;
+mod wait;
 
 pub use progress::AgentActiveWork;
 pub use progress::AgentActiveWorkKind;
@@ -8,3 +9,6 @@ pub use progress::AgentBlockReason;
 pub use progress::AgentProgressPhase;
 pub use progress::AgentProgressSnapshot;
 pub use progress::ProgressRegistry;
+pub use wait::WaitForAgentProgressMatchReason;
+pub use wait::WaitObservationMoment;
+pub use wait::classify_wait_observation;

--- a/codex-rs/agent-observability/src/progress.rs
+++ b/codex-rs/agent-observability/src/progress.rs
@@ -90,6 +90,14 @@ impl AgentProgressSnapshot {
             stalled: false,
         }
     }
+
+    pub fn phase(&self) -> AgentProgressPhase {
+        self.phase
+    }
+
+    pub fn seq(&self) -> u64 {
+        self.seq
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/codex-rs/agent-observability/src/wait.rs
+++ b/codex-rs/agent-observability/src/wait.rs
@@ -1,0 +1,107 @@
+use crate::AgentProgressPhase;
+use crate::AgentProgressSnapshot;
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaitObservationMoment {
+    Initial,
+    AfterProgress,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WaitForAgentProgressMatchReason {
+    AlreadySatisfied,
+    SeqAdvanced,
+    PhaseMatched,
+    TimedOut,
+}
+
+pub fn classify_wait_observation(
+    snapshot: &AgentProgressSnapshot,
+    baseline_seq: u64,
+    until_phases: &[AgentProgressPhase],
+    moment: WaitObservationMoment,
+) -> Option<WaitForAgentProgressMatchReason> {
+    if snapshot.seq() > baseline_seq {
+        Some(WaitForAgentProgressMatchReason::SeqAdvanced)
+    } else if until_phases.contains(&snapshot.phase()) {
+        Some(match moment {
+            WaitObservationMoment::Initial => WaitForAgentProgressMatchReason::AlreadySatisfied,
+            WaitObservationMoment::AfterProgress => WaitForAgentProgressMatchReason::PhaseMatched,
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AgentProgressPhase;
+    use codex_protocol::protocol::AgentStatus;
+    use pretty_assertions::assert_eq;
+
+    fn snapshot(seq: u64, phase: AgentProgressPhase) -> AgentProgressSnapshot {
+        AgentProgressSnapshot {
+            lifecycle_status: AgentStatus::Running,
+            phase,
+            blocked_on: None,
+            active_work: None,
+            recent_updates: Vec::new(),
+            latest_visible_message: None,
+            final_message: None,
+            error_message: None,
+            ever_entered_turn: true,
+            ever_reported_progress: true,
+            last_progress_age_ms: Some(10),
+            seq,
+            stalled: false,
+        }
+    }
+
+    #[test]
+    fn classify_wait_observation_prefers_seq_advanced_over_phase_match() {
+        let snapshot = snapshot(2, AgentProgressPhase::WaitingApproval);
+
+        assert_eq!(
+            classify_wait_observation(
+                &snapshot,
+                1,
+                &[AgentProgressPhase::WaitingApproval],
+                WaitObservationMoment::AfterProgress,
+            ),
+            Some(WaitForAgentProgressMatchReason::SeqAdvanced)
+        );
+    }
+
+    #[test]
+    fn classify_wait_observation_returns_already_satisfied_for_initial_phase_match() {
+        let snapshot = snapshot(3, AgentProgressPhase::WaitingUserInput);
+
+        assert_eq!(
+            classify_wait_observation(
+                &snapshot,
+                3,
+                &[AgentProgressPhase::WaitingUserInput],
+                WaitObservationMoment::Initial,
+            ),
+            Some(WaitForAgentProgressMatchReason::AlreadySatisfied)
+        );
+    }
+
+    #[test]
+    fn classify_wait_observation_returns_phase_matched_after_progress_observation() {
+        let snapshot = snapshot(3, AgentProgressPhase::WaitingUserInput);
+
+        assert_eq!(
+            classify_wait_observation(
+                &snapshot,
+                3,
+                &[AgentProgressPhase::WaitingUserInput],
+                WaitObservationMoment::AfterProgress,
+            ),
+            Some(WaitForAgentProgressMatchReason::PhaseMatched)
+        );
+    }
+}

--- a/codex-rs/core/src/tools/handlers/agent_progress.rs
+++ b/codex-rs/core/src/tools/handlers/agent_progress.rs
@@ -16,6 +16,9 @@ use crate::tools::registry::ToolHandler;
 use crate::tools::registry::ToolKind;
 use codex_agent_observability::AgentProgressPhase;
 use codex_agent_observability::AgentProgressSnapshot;
+use codex_agent_observability::WaitForAgentProgressMatchReason;
+use codex_agent_observability::WaitObservationMoment;
+use codex_agent_observability::classify_wait_observation;
 use codex_protocol::ThreadId;
 use codex_protocol::models::ResponseInputItem;
 use serde::Deserialize;
@@ -110,18 +113,16 @@ impl ToolHandler for WaitForAgentProgressHandler {
             .inspect_agent_progress(agent_id, Duration::from_millis(stalled_after))
             .await;
 
-        if snapshot.seq > baseline_seq {
+        if let Some(match_reason) = classify_wait_observation(
+            &snapshot,
+            baseline_seq,
+            &until_phases,
+            WaitObservationMoment::Initial,
+        ) {
             return Ok(WaitForAgentProgressResult::matched(
                 canonical_target.clone(),
                 snapshot,
-                WaitForAgentProgressMatchReason::SeqAdvanced,
-            ));
-        }
-        if until_phases.contains(&snapshot.phase) {
-            return Ok(WaitForAgentProgressResult::matched(
-                canonical_target.clone(),
-                snapshot,
-                WaitForAgentProgressMatchReason::AlreadySatisfied,
+                match_reason,
             ));
         }
         if *progress_seq_rx.borrow() > baseline_seq {
@@ -147,9 +148,12 @@ impl ToolHandler for WaitForAgentProgressHandler {
                         .agent_control
                         .inspect_agent_progress(agent_id, Duration::from_millis(stalled_after))
                         .await;
-                    if let Some(match_reason) =
-                        classify_wait_match(&snapshot, baseline_seq, &until_phases)
-                    {
+                    if let Some(match_reason) = classify_wait_observation(
+                        &snapshot,
+                        baseline_seq,
+                        &until_phases,
+                        WaitObservationMoment::AfterProgress,
+                    ) {
                         return Ok(WaitForAgentProgressResult::matched(
                             canonical_target.clone(),
                             snapshot,
@@ -163,9 +167,12 @@ impl ToolHandler for WaitForAgentProgressHandler {
                         .agent_control
                         .inspect_agent_progress(agent_id, Duration::from_millis(stalled_after))
                         .await;
-                    if let Some(match_reason) =
-                        classify_wait_match(&snapshot, baseline_seq, &until_phases)
-                    {
+                    if let Some(match_reason) = classify_wait_observation(
+                        &snapshot,
+                        baseline_seq,
+                        &until_phases,
+                        WaitObservationMoment::AfterProgress,
+                    ) {
                         return Ok(WaitForAgentProgressResult::matched(
                             canonical_target.clone(),
                             snapshot,
@@ -209,15 +216,6 @@ pub(crate) struct InspectAgentProgressResult {
     canonical_target: CanonicalAgentTarget,
     #[serde(flatten)]
     snapshot: AgentProgressSnapshot,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum WaitForAgentProgressMatchReason {
-    AlreadySatisfied,
-    SeqAdvanced,
-    PhaseMatched,
-    TimedOut,
 }
 
 #[derive(Debug, Serialize)]
@@ -380,20 +378,6 @@ fn canonical_agent_target(
     }
 }
 
-fn classify_wait_match(
-    snapshot: &AgentProgressSnapshot,
-    baseline_seq: u64,
-    until_phases: &[AgentProgressPhase],
-) -> Option<WaitForAgentProgressMatchReason> {
-    if snapshot.seq > baseline_seq {
-        Some(WaitForAgentProgressMatchReason::SeqAdvanced)
-    } else if until_phases.contains(&snapshot.phase) {
-        Some(WaitForAgentProgressMatchReason::PhaseMatched)
-    } else {
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -419,26 +403,6 @@ mod tests {
     }
 
     #[test]
-    fn classify_wait_match_prefers_seq_advanced_over_phase_match() {
-        let snapshot = snapshot(2, AgentProgressPhase::WaitingApproval);
-
-        assert_eq!(
-            classify_wait_match(&snapshot, 1, &[AgentProgressPhase::WaitingApproval]),
-            Some(WaitForAgentProgressMatchReason::SeqAdvanced)
-        );
-    }
-
-    #[test]
-    fn classify_wait_match_returns_phase_matched_without_seq_advance() {
-        let snapshot = snapshot(3, AgentProgressPhase::WaitingUserInput);
-
-        assert_eq!(
-            classify_wait_match(&snapshot, 3, &[AgentProgressPhase::WaitingUserInput]),
-            Some(WaitForAgentProgressMatchReason::PhaseMatched)
-        );
-    }
-
-    #[test]
     fn timed_out_wait_result_is_marked_as_timed_out() {
         let result = WaitForAgentProgressResult::timed_out(
             CanonicalAgentTarget {
@@ -455,5 +419,36 @@ mod tests {
             WaitForAgentProgressMatchReason::TimedOut
         );
         assert_eq!(result.message, "Wait for agent progress timed out.");
+    }
+
+    #[test]
+    fn matched_wait_result_reports_already_satisfied_message() {
+        let snapshot = snapshot(2, AgentProgressPhase::WaitingApproval);
+        let result = WaitForAgentProgressResult::matched(
+            CanonicalAgentTarget {
+                thread_id: "thread-1".to_string(),
+                task_name: "/root/worker".to_string(),
+                nickname: Some("worker".to_string()),
+            },
+            snapshot,
+            WaitForAgentProgressMatchReason::AlreadySatisfied,
+        );
+
+        assert_eq!(result.message, "Agent already satisfied wait condition.");
+    }
+
+    #[test]
+    fn matched_wait_result_reports_observed_progress_message() {
+        let result = WaitForAgentProgressResult::matched(
+            CanonicalAgentTarget {
+                thread_id: "thread-1".to_string(),
+                task_name: "/root/worker".to_string(),
+                nickname: Some("worker".to_string()),
+            },
+            snapshot(3, AgentProgressPhase::WaitingUserInput),
+            WaitForAgentProgressMatchReason::PhaseMatched,
+        );
+
+        assert_eq!(result.message, "Observed agent progress.");
     }
 }


### PR DESCRIPTION
## Summary
- move wait observation classification into `codex-agent-observability`
- distinguish initial `already_satisfied` from later `phase_matched` observations in one semantic owner
- keep timeout orchestration in `codex-core` while hardening snapshot access through explicit accessors

## Validation
- cargo test -p codex-agent-observability
- cargo test -p codex-core tools::handlers::agent_progress::tests --lib
- cargo test -p codex-core inspect_agent_progress_reports_reasoning_phase_for_live_subagent --lib
- cargo test -p codex-core wait_for_agent_progress_returns_on_material_progress --lib
- just fix -p codex-agent-observability
- just fix -p codex-core
- just fmt