### PR TITLE
[codex] Single-source agent observability tool contract

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1374,6 +1374,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "pretty_assertions",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -2886,6 +2887,7 @@ dependencies = [
 name = "codex-tools"
 version = "0.121.0"
 dependencies = [
+ "codex-agent-observability",
  "codex-app-server-protocol",
  "codex-code-mode",
  "codex-features",

--- a/codex-rs/agent-observability/Cargo.toml
+++ b/codex-rs/agent-observability/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 [dev-dependencies]
 codex-utils-absolute-path = { workspace = true }
 pretty_assertions = { workspace = true }
+serde_json = { workspace = true }

--- a/codex-rs/agent-observability/src/contract.rs
+++ b/codex-rs/agent-observability/src/contract.rs
@@ -1,0 +1,109 @@
+pub const INSPECT_AGENT_PROGRESS_TOOL_NAME: &str = "inspect_agent_progress";
+pub const WAIT_FOR_AGENT_PROGRESS_TOOL_NAME: &str = "wait_for_agent_progress";
+
+pub const AGENT_PROGRESS_PHASE_NAMES: &[&str] = &[
+    "pending",
+    "reasoning",
+    "message_drafting",
+    "command",
+    "tool_call",
+    "waiting_approval",
+    "waiting_user_input",
+    "completed",
+    "errored",
+    "interrupted",
+    "shutdown",
+];
+
+pub const AGENT_BLOCK_REASON_NAMES: &[&str] = &[
+    "exec_approval",
+    "patch_approval",
+    "permissions_request",
+    "user_input_request",
+    "elicitation_request",
+];
+
+pub const AGENT_ACTIVE_WORK_KIND_NAMES: &[&str] = &["reasoning", "message", "command", "tool"];
+
+pub const WAIT_FOR_AGENT_PROGRESS_MATCH_REASON_NAMES: &[&str] = &[
+    "already_satisfied",
+    "seq_advanced",
+    "phase_matched",
+    "timed_out",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AgentActiveWorkKind;
+    use crate::AgentBlockReason;
+    use crate::AgentProgressPhase;
+    use crate::WaitForAgentProgressMatchReason;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    #[test]
+    fn progress_contract_constants_match_current_runtime_contract() {
+        assert_eq!(INSPECT_AGENT_PROGRESS_TOOL_NAME, "inspect_agent_progress");
+        assert_eq!(WAIT_FOR_AGENT_PROGRESS_TOOL_NAME, "wait_for_agent_progress");
+        assert_eq!(
+            AGENT_PROGRESS_PHASE_NAMES,
+            &[
+                "pending",
+                "reasoning",
+                "message_drafting",
+                "command",
+                "tool_call",
+                "waiting_approval",
+                "waiting_user_input",
+                "completed",
+                "errored",
+                "interrupted",
+                "shutdown",
+            ]
+        );
+        assert_eq!(
+            AGENT_BLOCK_REASON_NAMES,
+            &[
+                "exec_approval",
+                "patch_approval",
+                "permissions_request",
+                "user_input_request",
+                "elicitation_request",
+            ]
+        );
+        assert_eq!(
+            AGENT_ACTIVE_WORK_KIND_NAMES,
+            &["reasoning", "message", "command", "tool"]
+        );
+        assert_eq!(
+            WAIT_FOR_AGENT_PROGRESS_MATCH_REASON_NAMES,
+            &[
+                "already_satisfied",
+                "seq_advanced",
+                "phase_matched",
+                "timed_out",
+            ]
+        );
+    }
+
+    #[test]
+    fn progress_contract_constants_match_serialized_enum_values() {
+        assert_eq!(
+            serde_json::to_value(AgentProgressPhase::WaitingApproval).unwrap(),
+            json!("waiting_approval")
+        );
+        assert_eq!(
+            serde_json::to_value(AgentBlockReason::PermissionsRequest).unwrap(),
+            json!("permissions_request")
+        );
+        assert_eq!(
+            serde_json::to_value(AgentActiveWorkKind::Command).unwrap(),
+            json!("command")
+        );
+        assert_eq!(
+            serde_json::to_value(WaitForAgentProgressMatchReason::PhaseMatched).unwrap(),
+            json!("phase_matched")
+        );
+    }
+}

--- a/codex-rs/agent-observability/src/contract.rs
+++ b/codex-rs/agent-observability/src/contract.rs
@@ -90,20 +90,72 @@ mod tests {
     #[test]
     fn progress_contract_constants_match_serialized_enum_values() {
         assert_eq!(
-            serde_json::to_value(AgentProgressPhase::WaitingApproval).unwrap(),
-            json!("waiting_approval")
+            [
+                AgentProgressPhase::Pending,
+                AgentProgressPhase::Reasoning,
+                AgentProgressPhase::MessageDrafting,
+                AgentProgressPhase::Command,
+                AgentProgressPhase::ToolCall,
+                AgentProgressPhase::WaitingApproval,
+                AgentProgressPhase::WaitingUserInput,
+                AgentProgressPhase::Completed,
+                AgentProgressPhase::Errored,
+                AgentProgressPhase::Interrupted,
+                AgentProgressPhase::Shutdown,
+            ]
+            .iter()
+            .map(|phase| serde_json::to_value(phase).unwrap())
+            .collect::<Vec<_>>(),
+            AGENT_PROGRESS_PHASE_NAMES
+                .iter()
+                .map(|name| json!(name))
+                .collect::<Vec<_>>()
         );
         assert_eq!(
-            serde_json::to_value(AgentBlockReason::PermissionsRequest).unwrap(),
-            json!("permissions_request")
+            [
+                AgentBlockReason::ExecApproval,
+                AgentBlockReason::PatchApproval,
+                AgentBlockReason::PermissionsRequest,
+                AgentBlockReason::UserInputRequest,
+                AgentBlockReason::ElicitationRequest,
+            ]
+            .iter()
+            .map(|reason| serde_json::to_value(reason).unwrap())
+            .collect::<Vec<_>>(),
+            AGENT_BLOCK_REASON_NAMES
+                .iter()
+                .map(|name| json!(name))
+                .collect::<Vec<_>>()
         );
         assert_eq!(
-            serde_json::to_value(AgentActiveWorkKind::Command).unwrap(),
-            json!("command")
+            [
+                AgentActiveWorkKind::Reasoning,
+                AgentActiveWorkKind::Message,
+                AgentActiveWorkKind::Command,
+                AgentActiveWorkKind::Tool,
+            ]
+            .iter()
+            .map(|kind| serde_json::to_value(kind).unwrap())
+            .collect::<Vec<_>>(),
+            AGENT_ACTIVE_WORK_KIND_NAMES
+                .iter()
+                .map(|name| json!(name))
+                .collect::<Vec<_>>()
         );
         assert_eq!(
-            serde_json::to_value(WaitForAgentProgressMatchReason::PhaseMatched).unwrap(),
-            json!("phase_matched")
+            [
+                WaitForAgentProgressMatchReason::AlreadySatisfied,
+                WaitForAgentProgressMatchReason::SeqAdvanced,
+                WaitForAgentProgressMatchReason::PhaseMatched,
+                WaitForAgentProgressMatchReason::TimedOut,
+            ]
+            .iter()
+            .map(|reason| serde_json::to_value(reason).unwrap())
+            .collect::<Vec<_>>(),
+            WAIT_FOR_AGENT_PROGRESS_MATCH_REASON_NAMES
+                .iter()
+                .map(|name| json!(name))
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/codex-rs/agent-observability/src/lib.rs
+++ b/codex-rs/agent-observability/src/lib.rs
@@ -1,8 +1,15 @@
 //! Semantic owner for agent progress observation and reduction.
 
+mod contract;
 mod progress;
 mod wait;
 
+pub use contract::AGENT_ACTIVE_WORK_KIND_NAMES;
+pub use contract::AGENT_BLOCK_REASON_NAMES;
+pub use contract::AGENT_PROGRESS_PHASE_NAMES;
+pub use contract::INSPECT_AGENT_PROGRESS_TOOL_NAME;
+pub use contract::WAIT_FOR_AGENT_PROGRESS_MATCH_REASON_NAMES;
+pub use contract::WAIT_FOR_AGENT_PROGRESS_TOOL_NAME;
 pub use progress::AgentActiveWork;
 pub use progress::AgentActiveWorkKind;
 pub use progress::AgentBlockReason;

--- a/codex-rs/core/src/tools/handlers/agent_progress.rs
+++ b/codex-rs/core/src/tools/handlers/agent_progress.rs
@@ -16,6 +16,8 @@ use crate::tools::registry::ToolHandler;
 use crate::tools::registry::ToolKind;
 use codex_agent_observability::AgentProgressPhase;
 use codex_agent_observability::AgentProgressSnapshot;
+use codex_agent_observability::INSPECT_AGENT_PROGRESS_TOOL_NAME;
+use codex_agent_observability::WAIT_FOR_AGENT_PROGRESS_TOOL_NAME;
 use codex_agent_observability::WaitForAgentProgressMatchReason;
 use codex_agent_observability::WaitObservationMoment;
 use codex_agent_observability::classify_wait_observation;
@@ -264,25 +266,7 @@ impl WaitForAgentProgressResult {
 
 impl ToolOutput for InspectAgentProgressResult {
     fn log_preview(&self) -> String {
-        tool_output_json_text(self, "inspect_agent_progress")
-    }
-
-    fn success_for_logging(&self) -> bool {
-        true
-    }
-
-    fn to_response_item(&self, call_id: &str, payload: &ToolPayload) -> ResponseInputItem {
-        tool_output_response_item(call_id, payload, self, Some(true), "inspect_agent_progress")
-    }
-
-    fn code_mode_result(&self, _payload: &ToolPayload) -> JsonValue {
-        tool_output_code_mode_result(self, "inspect_agent_progress")
-    }
-}
-
-impl ToolOutput for WaitForAgentProgressResult {
-    fn log_preview(&self) -> String {
-        tool_output_json_text(self, "wait_for_agent_progress")
+        tool_output_json_text(self, INSPECT_AGENT_PROGRESS_TOOL_NAME)
     }
 
     fn success_for_logging(&self) -> bool {
@@ -295,12 +279,36 @@ impl ToolOutput for WaitForAgentProgressResult {
             payload,
             self,
             Some(true),
-            "wait_for_agent_progress",
+            INSPECT_AGENT_PROGRESS_TOOL_NAME,
         )
     }
 
     fn code_mode_result(&self, _payload: &ToolPayload) -> JsonValue {
-        tool_output_code_mode_result(self, "wait_for_agent_progress")
+        tool_output_code_mode_result(self, INSPECT_AGENT_PROGRESS_TOOL_NAME)
+    }
+}
+
+impl ToolOutput for WaitForAgentProgressResult {
+    fn log_preview(&self) -> String {
+        tool_output_json_text(self, WAIT_FOR_AGENT_PROGRESS_TOOL_NAME)
+    }
+
+    fn success_for_logging(&self) -> bool {
+        true
+    }
+
+    fn to_response_item(&self, call_id: &str, payload: &ToolPayload) -> ResponseInputItem {
+        tool_output_response_item(
+            call_id,
+            payload,
+            self,
+            Some(true),
+            WAIT_FOR_AGENT_PROGRESS_TOOL_NAME,
+        )
+    }
+
+    fn code_mode_result(&self, _payload: &ToolPayload) -> JsonValue {
+        tool_output_code_mode_result(self, WAIT_FOR_AGENT_PROGRESS_TOOL_NAME)
     }
 }
 

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -8,6 +8,8 @@ use crate::tools::context::ToolPayload;
 use crate::tools::registry::AnyToolResult;
 use crate::tools::registry::ToolRegistry;
 use crate::tools::spec::build_specs_with_discoverable_tools;
+use codex_agent_observability::INSPECT_AGENT_PROGRESS_TOOL_NAME;
+use codex_agent_observability::WAIT_FOR_AGENT_PROGRESS_TOOL_NAME;
 use codex_mcp::ToolInfo;
 use codex_protocol::dynamic_tools::DynamicToolSpec;
 use codex_protocol::models::LocalShellAction;
@@ -31,7 +33,7 @@ fn model_visible_in_code_mode_only(tool_name: &str) -> bool {
     !codex_code_mode::is_code_mode_nested_tool(tool_name)
         && !matches!(
             tool_name,
-            "inspect_agent_progress" | "wait_for_agent_progress"
+            INSPECT_AGENT_PROGRESS_TOOL_NAME | WAIT_FOR_AGENT_PROGRESS_TOOL_NAME
         )
 }
 

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -4,6 +4,8 @@ use crate::shell::ShellType;
 use crate::test_support::construct_model_info_offline;
 use crate::tools::ToolRouter;
 use crate::tools::router::ToolRouterParams;
+use codex_agent_observability::INSPECT_AGENT_PROGRESS_TOOL_NAME;
+use codex_agent_observability::WAIT_FOR_AGENT_PROGRESS_TOOL_NAME;
 use codex_app_server_protocol::AppInfo;
 use codex_features::Feature;
 use codex_features::Features;
@@ -382,15 +384,15 @@ fn assert_model_tools(
     let mut expected_tool_names = expected_tools.to_vec();
     if features.enabled(Feature::Collab)
         && !tools_config.code_mode_only_enabled
-        && !expected_tool_names.contains(&"inspect_agent_progress")
-        && !expected_tool_names.contains(&"wait_for_agent_progress")
+        && !expected_tool_names.contains(&INSPECT_AGENT_PROGRESS_TOOL_NAME)
+        && !expected_tool_names.contains(&WAIT_FOR_AGENT_PROGRESS_TOOL_NAME)
     {
         let insert_at = expected_tool_names
             .iter()
             .position(|name| *name == "spawn_agent")
             .unwrap_or(expected_tool_names.len());
-        expected_tool_names.insert(insert_at, "inspect_agent_progress");
-        expected_tool_names.insert(insert_at + 1, "wait_for_agent_progress");
+        expected_tool_names.insert(insert_at, INSPECT_AGENT_PROGRESS_TOOL_NAME);
+        expected_tool_names.insert(insert_at + 1, WAIT_FOR_AGENT_PROGRESS_TOOL_NAME);
     }
     assert_eq!(&tool_names, &expected_tool_names,);
 }
@@ -805,8 +807,8 @@ fn collab_tools_include_agent_progress_tools() {
     assert_contains_tool_names(
         &tools,
         &[
-            "inspect_agent_progress",
-            "wait_for_agent_progress",
+            INSPECT_AGENT_PROGRESS_TOOL_NAME,
+            WAIT_FOR_AGENT_PROGRESS_TOOL_NAME,
             "spawn_agent",
         ],
     );
@@ -825,7 +827,10 @@ fn thread_spawn_subagent_hides_spawn_agent_tool_v1() {
 
     assert_contains_tool_names(
         &tools,
-        &["inspect_agent_progress", "wait_for_agent_progress"],
+        &[
+            INSPECT_AGENT_PROGRESS_TOOL_NAME,
+            WAIT_FOR_AGENT_PROGRESS_TOOL_NAME,
+        ],
     );
     assert_lacks_tool_name(&tools, "spawn_agent");
     assert_lacks_tool_name(&tools, "request_user_input");
@@ -845,8 +850,8 @@ fn thread_spawn_subagent_hides_spawn_agent_tool_v2() {
     assert_contains_tool_names(
         &tools,
         &[
-            "inspect_agent_progress",
-            "wait_for_agent_progress",
+            INSPECT_AGENT_PROGRESS_TOOL_NAME,
+            WAIT_FOR_AGENT_PROGRESS_TOOL_NAME,
             "send_message",
             "followup_task",
             "wait_agent",

--- a/codex-rs/tools/Cargo.toml
+++ b/codex-rs/tools/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
+codex-agent-observability = { workspace = true }
 codex-app-server-protocol = { workspace = true }
 codex-code-mode = { workspace = true }
 codex-features = { workspace = true }

--- a/codex-rs/tools/src/agent_progress_tool.rs
+++ b/codex-rs/tools/src/agent_progress_tool.rs
@@ -1,6 +1,12 @@
 use crate::JsonSchema;
 use crate::ResponsesApiTool;
 use crate::ToolSpec;
+use codex_agent_observability::AGENT_ACTIVE_WORK_KIND_NAMES;
+use codex_agent_observability::AGENT_BLOCK_REASON_NAMES;
+use codex_agent_observability::AGENT_PROGRESS_PHASE_NAMES;
+use codex_agent_observability::INSPECT_AGENT_PROGRESS_TOOL_NAME;
+use codex_agent_observability::WAIT_FOR_AGENT_PROGRESS_MATCH_REASON_NAMES;
+use codex_agent_observability::WAIT_FOR_AGENT_PROGRESS_TOOL_NAME;
 use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -23,7 +29,7 @@ pub fn create_inspect_agent_progress_tool() -> ToolSpec {
     ]);
 
     ToolSpec::Function(ResponsesApiTool {
-        name: "inspect_agent_progress".to_string(),
+        name: INSPECT_AGENT_PROGRESS_TOOL_NAME.to_string(),
         description: "Inspect normalized live progress for an existing agent. Use this when you need to know whether a sub-agent has entered its turn, started meaningful work, is blocked on approval or user input, or appears stalled."
             .to_string(),
         strict: false,
@@ -79,7 +85,7 @@ pub fn create_wait_for_agent_progress_tool() -> ToolSpec {
     ]);
 
     ToolSpec::Function(ResponsesApiTool {
-        name: "wait_for_agent_progress".to_string(),
+        name: WAIT_FOR_AGENT_PROGRESS_TOOL_NAME.to_string(),
         description: "Wait for meaningful progress from an existing agent. Use this after an initial inspect to block until seq advances, a target phase is reached, or the timeout expires."
             .to_string(),
         strict: false,
@@ -125,19 +131,16 @@ fn agent_status_output_schema() -> Value {
 }
 
 fn phase_enum_schema() -> Value {
-    json!([
-        "pending",
-        "reasoning",
-        "message_drafting",
-        "command",
-        "tool_call",
-        "waiting_approval",
-        "waiting_user_input",
-        "completed",
-        "errored",
-        "interrupted",
-        "shutdown"
-    ])
+    json!(AGENT_PROGRESS_PHASE_NAMES)
+}
+
+fn blocked_on_enum_schema() -> Value {
+    let mut values = AGENT_BLOCK_REASON_NAMES
+        .iter()
+        .map(|value| json!(value))
+        .collect::<Vec<_>>();
+    values.push(Value::Null);
+    Value::Array(values)
 }
 
 fn agent_progress_snapshot_properties() -> Value {
@@ -153,14 +156,7 @@ fn agent_progress_snapshot_properties() -> Value {
         },
         "blocked_on": {
             "type": ["string", "null"],
-            "enum": [
-                "exec_approval",
-                "patch_approval",
-                "permissions_request",
-                "user_input_request",
-                "elicitation_request",
-                null
-            ],
+            "enum": blocked_on_enum_schema(),
             "description": "Blocking condition when the agent is waiting on an external decision."
         },
         "active_work": {
@@ -168,7 +164,7 @@ fn agent_progress_snapshot_properties() -> Value {
             "properties": {
                 "kind": {
                     "type": "string",
-                    "enum": ["reasoning", "message", "command", "tool"]
+                    "enum": AGENT_ACTIVE_WORK_KIND_NAMES
                 },
                 "label": {
                     "type": "string"
@@ -293,7 +289,7 @@ fn wait_for_agent_progress_output_schema() -> Value {
             },
             "match_reason": {
                 "type": "string",
-                "enum": ["already_satisfied", "seq_advanced", "phase_matched", "timed_out"]
+                "enum": WAIT_FOR_AGENT_PROGRESS_MATCH_REASON_NAMES
             },
             "canonical_target": canonical_target_output_schema(),
             "lifecycle_status": agent_progress_snapshot_properties()["lifecycle_status"].clone(),
@@ -366,18 +362,11 @@ mod tests {
         );
         assert_eq!(
             output_schema["properties"]["blocked_on"]["enum"],
-            json!([
-                "exec_approval",
-                "patch_approval",
-                "permissions_request",
-                "user_input_request",
-                "elicitation_request",
-                null
-            ])
+            blocked_on_enum_schema()
         );
         assert_eq!(
             output_schema["properties"]["active_work"]["properties"]["kind"]["enum"],
-            json!(["reasoning", "message", "command", "tool"])
+            json!(AGENT_ACTIVE_WORK_KIND_NAMES)
         );
         assert_eq!(
             output_schema["properties"]["ever_reported_progress"]["type"],
@@ -407,12 +396,7 @@ mod tests {
         let output_schema = output_schema.expect("wait_for_agent_progress output schema");
         assert_eq!(
             output_schema["properties"]["match_reason"]["enum"],
-            json!([
-                "already_satisfied",
-                "seq_advanced",
-                "phase_matched",
-                "timed_out"
-            ])
+            json!(WAIT_FOR_AGENT_PROGRESS_MATCH_REASON_NAMES)
         );
         assert_eq!(
             output_schema["properties"]["canonical_target"]["required"],

--- a/codex-rs/tools/src/tool_registry_plan.rs
+++ b/codex-rs/tools/src/tool_registry_plan.rs
@@ -63,6 +63,8 @@ use crate::mcp_tool_to_responses_api_tool;
 use crate::request_permissions_tool_description;
 use crate::request_user_input_tool_description;
 use crate::tool_registry_plan_types::agent_type_description;
+use codex_agent_observability::INSPECT_AGENT_PROGRESS_TOOL_NAME;
+use codex_agent_observability::WAIT_FOR_AGENT_PROGRESS_TOOL_NAME;
 use codex_protocol::openai_models::ApplyPatchToolType;
 use codex_protocol::openai_models::ConfigShellToolType;
 use std::collections::BTreeMap;
@@ -378,11 +380,11 @@ pub fn build_tool_registry_plan(
             config.code_mode_enabled,
         );
         plan.register_handler(
-            "inspect_agent_progress",
+            INSPECT_AGENT_PROGRESS_TOOL_NAME,
             ToolHandlerKind::InspectAgentProgress,
         );
         plan.register_handler(
-            "wait_for_agent_progress",
+            WAIT_FOR_AGENT_PROGRESS_TOOL_NAME,
             ToolHandlerKind::WaitForAgentProgress,
         );
 


### PR DESCRIPTION
## Summary
- add observability-owned contract constants for tool names and model-visible enum domains
- make `codex-tools` build agent progress schemas from those shared constants
- switch core routing and related spec surfaces to the same tool-name constants

## Validation
- cargo test -p codex-agent-observability
- cargo test -p codex-tools agent_progress_tool --lib
- cargo test -p codex-tools tool_registry_plan --lib
- cargo test -p codex-core thread_spawn_subagent_hides_spawn_agent_tool_v1 --lib
- cargo test -p codex-core thread_spawn_subagent_hides_spawn_agent_tool_v2 --lib
- just bazel-lock-update
- just bazel-lock-check
- just fix -p codex-agent-observability
- just fix -p codex-tools
- just fix -p codex-core
- just fmt