### PR TITLE
[codex] Make agent tool surface policy explicit

### DIFF
--- a/codex-rs/tools/src/tool_config.rs
+++ b/codex-rs/tools/src/tool_config.rs
@@ -39,7 +39,7 @@ pub enum UnifiedExecShellMode {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct AgentToolSurfacePolicy {
-    pub progress_observability_enabled: bool,
+    pub collaboration_enabled: bool,
     pub spawn_agent_enabled: bool,
     pub request_user_input_enabled: bool,
 }
@@ -47,7 +47,7 @@ pub struct AgentToolSurfacePolicy {
 impl AgentToolSurfacePolicy {
     fn for_session(session_source: &SessionSource, collab_enabled: bool) -> Self {
         Self {
-            progress_observability_enabled: collab_enabled,
+            collaboration_enabled: collab_enabled,
             spawn_agent_enabled: collab_enabled
                 && !matches!(
                     session_source,

--- a/codex-rs/tools/src/tool_config.rs
+++ b/codex-rs/tools/src/tool_config.rs
@@ -37,6 +37,27 @@ pub enum UnifiedExecShellMode {
     ZshFork(ZshForkConfig),
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct AgentToolSurfacePolicy {
+    pub progress_observability_enabled: bool,
+    pub spawn_agent_enabled: bool,
+    pub request_user_input_enabled: bool,
+}
+
+impl AgentToolSurfacePolicy {
+    fn for_session(session_source: &SessionSource, collab_enabled: bool) -> Self {
+        Self {
+            progress_observability_enabled: collab_enabled,
+            spawn_agent_enabled: collab_enabled
+                && !matches!(
+                    session_source,
+                    SessionSource::SubAgent(SubAgentSource::ThreadSpawn { .. })
+                ),
+            request_user_input_enabled: !matches!(session_source, SessionSource::SubAgent(_)),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ZshForkConfig {
     pub shell_zsh_path: AbsolutePathBuf,
@@ -102,10 +123,8 @@ pub struct ToolsConfig {
     pub js_repl_enabled: bool,
     pub js_repl_tools_only: bool,
     pub can_request_original_image_detail: bool,
-    pub collab_tools: bool,
     pub multi_agent_v2: bool,
-    pub spawn_agent_enabled: bool,
-    pub request_user_input_enabled: bool,
+    pub agent_tool_surface_policy: AgentToolSurfacePolicy,
     pub hide_spawn_agent_metadata: bool,
     pub spawn_agent_usage_hint: bool,
     pub spawn_agent_usage_hint_text: Option<String>,
@@ -148,12 +167,8 @@ impl ToolsConfig {
         let include_collab_tools = features.enabled(Feature::Collab);
         let include_multi_agent_v2 = features.enabled(Feature::MultiAgentV2);
         let include_agent_jobs = features.enabled(Feature::SpawnCsv);
-        let include_spawn_agent = include_collab_tools
-            && !matches!(
-                session_source,
-                SessionSource::SubAgent(SubAgentSource::ThreadSpawn { .. })
-            );
-        let include_request_user_input = !matches!(session_source, SessionSource::SubAgent(_));
+        let agent_tool_surface_policy =
+            AgentToolSurfacePolicy::for_session(session_source, include_collab_tools);
         let include_default_mode_request_user_input =
             features.enabled(Feature::DefaultModeRequestUserInput);
         let include_search_tool =
@@ -231,10 +246,8 @@ impl ToolsConfig {
             js_repl_enabled: include_js_repl,
             js_repl_tools_only: include_js_repl_tools_only,
             can_request_original_image_detail: include_original_image_detail,
-            collab_tools: include_collab_tools,
             multi_agent_v2: include_multi_agent_v2,
-            spawn_agent_enabled: include_spawn_agent,
-            request_user_input_enabled: include_request_user_input,
+            agent_tool_surface_policy,
             hide_spawn_agent_metadata: false,
             spawn_agent_usage_hint: true,
             spawn_agent_usage_hint_text: None,

--- a/codex-rs/tools/src/tool_config_tests.rs
+++ b/codex-rs/tools/src/tool_config_tests.rs
@@ -155,6 +155,49 @@ fn subagents_keep_request_user_input_mode_config_and_agent_jobs_workers_opt_in_b
     assert!(tools_config.default_mode_request_user_input);
     assert!(tools_config.agent_jobs_tools);
     assert!(tools_config.agent_jobs_worker_tools);
+    assert_eq!(
+        tools_config.agent_tool_surface_policy,
+        AgentToolSurfacePolicy {
+            progress_observability_enabled: true,
+            spawn_agent_enabled: true,
+            request_user_input_enabled: false,
+        }
+    );
+}
+
+#[test]
+fn thread_spawn_subagents_keep_observability_but_hide_spawn_and_request_user_input() {
+    let model_info = model_info();
+    let mut features = Features::with_defaults();
+    features.enable(Feature::Collab);
+    features.enable(Feature::MultiAgentV2);
+
+    let available_models = Vec::new();
+    let tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &features,
+        image_generation_tool_auth_allowed: true,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+            parent_thread_id: Default::default(),
+            depth: 1,
+            agent_path: None,
+            agent_nickname: None,
+            agent_role: None,
+        }),
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    });
+
+    assert_eq!(
+        tools_config.agent_tool_surface_policy,
+        AgentToolSurfacePolicy {
+            progress_observability_enabled: true,
+            spawn_agent_enabled: false,
+            request_user_input_enabled: false,
+        }
+    );
 }
 
 #[test]

--- a/codex-rs/tools/src/tool_config_tests.rs
+++ b/codex-rs/tools/src/tool_config_tests.rs
@@ -158,7 +158,7 @@ fn subagents_keep_request_user_input_mode_config_and_agent_jobs_workers_opt_in_b
     assert_eq!(
         tools_config.agent_tool_surface_policy,
         AgentToolSurfacePolicy {
-            progress_observability_enabled: true,
+            collaboration_enabled: true,
             spawn_agent_enabled: true,
             request_user_input_enabled: false,
         }
@@ -193,7 +193,7 @@ fn thread_spawn_subagents_keep_observability_but_hide_spawn_and_request_user_inp
     assert_eq!(
         tools_config.agent_tool_surface_policy,
         AgentToolSurfacePolicy {
-            progress_observability_enabled: true,
+            collaboration_enabled: true,
             spawn_agent_enabled: false,
             request_user_input_enabled: false,
         }

--- a/codex-rs/tools/src/tool_registry_plan.rs
+++ b/codex-rs/tools/src/tool_registry_plan.rs
@@ -230,7 +230,7 @@ pub fn build_tool_registry_plan(
         plan.register_handler("js_repl_reset", ToolHandlerKind::JsReplReset);
     }
 
-    if config.request_user_input_enabled {
+    if config.agent_tool_surface_policy.request_user_input_enabled {
         plan.push_spec(
             create_request_user_input_tool(request_user_input_tool_description(
                 config.default_mode_request_user_input,
@@ -368,7 +368,10 @@ pub fn build_tool_registry_plan(
         plan.register_handler("view_image", ToolHandlerKind::ViewImage);
     }
 
-    if config.collab_tools {
+    if config
+        .agent_tool_surface_policy
+        .progress_observability_enabled
+    {
         plan.push_spec(
             create_inspect_agent_progress_tool(),
             /*supports_parallel_tool_calls*/ false,
@@ -391,7 +394,7 @@ pub fn build_tool_registry_plan(
         if config.multi_agent_v2 {
             let agent_type_description =
                 agent_type_description(config, params.default_agent_type_description);
-            if config.spawn_agent_enabled {
+            if config.agent_tool_surface_policy.spawn_agent_enabled {
                 plan.push_spec(
                     create_spawn_agent_tool_v2(SpawnAgentToolOptions {
                         available_models: &config.available_models,
@@ -429,7 +432,7 @@ pub fn build_tool_registry_plan(
                 /*supports_parallel_tool_calls*/ false,
                 config.code_mode_enabled,
             );
-            if config.spawn_agent_enabled {
+            if config.agent_tool_surface_policy.spawn_agent_enabled {
                 plan.register_handler("spawn_agent", ToolHandlerKind::SpawnAgentV2);
             }
             plan.register_handler("send_message", ToolHandlerKind::SendMessageV2);
@@ -440,7 +443,7 @@ pub fn build_tool_registry_plan(
         } else {
             let agent_type_description =
                 agent_type_description(config, params.default_agent_type_description);
-            if config.spawn_agent_enabled {
+            if config.agent_tool_surface_policy.spawn_agent_enabled {
                 plan.push_spec(
                     create_spawn_agent_tool_v1(SpawnAgentToolOptions {
                         available_models: &config.available_models,
@@ -474,7 +477,7 @@ pub fn build_tool_registry_plan(
                 /*supports_parallel_tool_calls*/ false,
                 config.code_mode_enabled,
             );
-            if config.spawn_agent_enabled {
+            if config.agent_tool_surface_policy.spawn_agent_enabled {
                 plan.register_handler("spawn_agent", ToolHandlerKind::SpawnAgentV1);
             }
             plan.register_handler("send_input", ToolHandlerKind::SendInputV1);

--- a/codex-rs/tools/src/tool_registry_plan.rs
+++ b/codex-rs/tools/src/tool_registry_plan.rs
@@ -368,10 +368,7 @@ pub fn build_tool_registry_plan(
         plan.register_handler("view_image", ToolHandlerKind::ViewImage);
     }
 
-    if config
-        .agent_tool_surface_policy
-        .progress_observability_enabled
-    {
+    if config.agent_tool_surface_policy.collaboration_enabled {
         plan.push_spec(
             create_inspect_agent_progress_tool(),
             /*supports_parallel_tool_calls*/ false,

--- a/codex-rs/tools/src/tool_registry_plan_tests.rs
+++ b/codex-rs/tools/src/tool_registry_plan_tests.rs
@@ -103,27 +103,37 @@ fn test_full_toolset_specs_for_gpt5_codex_unified_exec_web_search() {
     ] {
         expected.insert(spec.name().to_string(), spec);
     }
-    let collab_specs = if config.multi_agent_v2 {
-        vec![
+    if config
+        .agent_tool_surface_policy
+        .progress_observability_enabled
+    {
+        let mut collab_specs = vec![
             create_inspect_agent_progress_tool(),
             create_wait_for_agent_progress_tool(),
-            create_spawn_agent_tool_v2(spawn_agent_tool_options(&config)),
-            create_send_message_tool(),
-            create_wait_agent_tool_v2(wait_agent_timeout_options()),
-            create_close_agent_tool_v2(),
-        ]
-    } else {
-        vec![
-            create_inspect_agent_progress_tool(),
-            create_wait_for_agent_progress_tool(),
-            create_spawn_agent_tool_v1(spawn_agent_tool_options(&config)),
-            create_send_input_tool_v1(),
-            create_wait_agent_tool_v1(wait_agent_timeout_options()),
-            create_close_agent_tool_v1(),
-        ]
-    };
-    for spec in collab_specs {
-        expected.insert(spec.name().to_string(), spec);
+        ];
+        if config.multi_agent_v2 {
+            if config.agent_tool_surface_policy.spawn_agent_enabled {
+                collab_specs.push(create_spawn_agent_tool_v2(spawn_agent_tool_options(
+                    &config,
+                )));
+            }
+            collab_specs.push(create_send_message_tool());
+            collab_specs.push(create_wait_agent_tool_v2(wait_agent_timeout_options()));
+            collab_specs.push(create_close_agent_tool_v2());
+        } else {
+            if config.agent_tool_surface_policy.spawn_agent_enabled {
+                collab_specs.push(create_spawn_agent_tool_v1(spawn_agent_tool_options(
+                    &config,
+                )));
+            }
+            collab_specs.push(create_send_input_tool_v1());
+            collab_specs.push(create_wait_agent_tool_v1(wait_agent_timeout_options()));
+            collab_specs.push(create_close_agent_tool_v1());
+        }
+
+        for spec in collab_specs {
+            expected.insert(spec.name().to_string(), spec);
+        }
     }
     if !config.multi_agent_v2 {
         let spec = create_resume_agent_tool();

--- a/codex-rs/tools/src/tool_registry_plan_tests.rs
+++ b/codex-rs/tools/src/tool_registry_plan_tests.rs
@@ -103,10 +103,7 @@ fn test_full_toolset_specs_for_gpt5_codex_unified_exec_web_search() {
     ] {
         expected.insert(spec.name().to_string(), spec);
     }
-    if config
-        .agent_tool_surface_policy
-        .progress_observability_enabled
-    {
+    if config.agent_tool_surface_policy.collaboration_enabled {
         let mut collab_specs = vec![
             create_inspect_agent_progress_tool(),
             create_wait_for_agent_progress_tool(),


### PR DESCRIPTION
## Summary
- replace the loose agent-tool booleans in `ToolsConfig` with an explicit `AgentToolSurfacePolicy`
- drive `tool_registry_plan` from that typed policy instead of re-encoding thread-spawn containment in local checks
- add focused `codex-tools` tests that lock the thread-spawn and sub-agent policy outcomes

## Validation
- cargo test -p codex-tools tool_registry_plan --lib
- cargo test -p codex-tools subagents_keep_request_user_input_mode_config_and_agent_jobs_workers_opt_in_by_label --lib
- cargo test -p codex-tools thread_spawn_subagents_keep_observability_but_hide_spawn_and_request_user_input --lib
- cargo test -p codex-core thread_spawn_subagent_hides_spawn_agent_tool_v1 --lib
- cargo test -p codex-core thread_spawn_subagent_hides_spawn_agent_tool_v2 --lib
- just fix -p codex-tools
- just fmt