### PR TITLE
[codex] Harden maintenance disposition helpers

### DIFF
--- a/codex-rs/context-maintenance-policy/src/artifact_codecs.rs
+++ b/codex-rs/context-maintenance-policy/src/artifact_codecs.rs
@@ -183,26 +183,9 @@ pub fn build_prune_manifest_item(
     })
 }
 
-/// Applies history disposition policies that do not require compaction-summary
-/// classification.
-///
-/// Callers that use [`SummaryDispositionPolicy::KeepLatestCompactionSummary`]
-/// must instead use [`apply_history_disposition_with_summary_classifier`] so
-/// the policy crate can identify summary messages correctly.
-pub fn apply_history_disposition(request: HistoryDispositionRequest) -> HistoryDispositionResult {
-    debug_assert!(
-        !matches!(
-            request.policy.summary_disposition,
-            SummaryDispositionPolicy::KeepLatestCompactionSummary
-        ),
-        "KeepLatestCompactionSummary requires apply_history_disposition_with_summary_classifier"
-    );
-    apply_history_disposition_with_summary_classifier(request, |_| false)
-}
-
 /// Applies history disposition policies, including summary disposition when the
 /// caller provides a compaction-summary classifier.
-pub fn apply_history_disposition_with_summary_classifier<F>(
+pub fn apply_history_disposition<F>(
     request: HistoryDispositionRequest,
     is_compaction_summary_message: F,
 ) -> HistoryDispositionResult
@@ -261,6 +244,20 @@ where
     }
 }
 
+#[cfg(test)]
+fn apply_history_disposition_without_summary_retention(
+    request: HistoryDispositionRequest,
+) -> HistoryDispositionResult {
+    debug_assert!(
+        !matches!(
+            request.policy.summary_disposition,
+            SummaryDispositionPolicy::KeepLatestCompactionSummary
+        ),
+        "KeepLatestCompactionSummary requires apply_history_disposition with a classifier"
+    );
+    apply_history_disposition(request, |_| false)
+}
+
 fn keep_latest_compaction_summary<F>(
     items: Vec<ResponseItem>,
     is_compaction_summary_message: F,
@@ -302,7 +299,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::apply_history_disposition;
-    use super::apply_history_disposition_with_summary_classifier;
+    use super::apply_history_disposition_without_summary_retention;
     use super::build_prune_manifest_item;
     use super::extract_tagged_payload;
     use super::has_tagged_block;
@@ -479,23 +476,24 @@ mod tests {
 
     #[test]
     fn apply_history_disposition_prunes_drops_and_strips_markers() {
-        let result = apply_history_disposition(HistoryDispositionRequest {
-            items: vec![
-                developer_message("<thread_memory>old</thread_memory>"),
-                developer_message("<thread_memory>new</thread_memory>"),
-                developer_message("<prune_manifest>old</prune_manifest>"),
-                ResponseItem::Compaction {
-                    encrypted_content: "encrypted".to_string(),
+        let result =
+            apply_history_disposition_without_summary_retention(HistoryDispositionRequest {
+                items: vec![
+                    developer_message("<thread_memory>old</thread_memory>"),
+                    developer_message("<thread_memory>new</thread_memory>"),
+                    developer_message("<prune_manifest>old</prune_manifest>"),
+                    ResponseItem::Compaction {
+                        encrypted_content: "encrypted".to_string(),
+                    },
+                ],
+                policy: HistoryDispositionPolicy {
+                    prune_superseded_artifacts: true,
+                    summary_disposition: SummaryDispositionPolicy::KeepAll,
+                    remote_keep_policy: RemoteCompactedHistoryKeepPolicy::KeepAll,
+                    drop_prior_artifact_kinds: vec![ArtifactKind::PruneManifest],
+                    legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy::Strip,
                 },
-            ],
-            policy: HistoryDispositionPolicy {
-                prune_superseded_artifacts: true,
-                summary_disposition: SummaryDispositionPolicy::KeepAll,
-                remote_keep_policy: RemoteCompactedHistoryKeepPolicy::KeepAll,
-                drop_prior_artifact_kinds: vec![ArtifactKind::PruneManifest],
-                legacy_compaction_marker_policy: LegacyCompactionMarkerPolicy::Strip,
-            },
-        });
+            });
 
         assert_eq!(
             result,
@@ -512,17 +510,18 @@ mod tests {
             encrypted_content: "encrypted".to_string(),
         };
 
-        let result = apply_history_disposition(HistoryDispositionRequest {
-            items: vec![marker.clone()],
-            policy: HistoryDispositionPolicy {
-                prune_superseded_artifacts: false,
-                summary_disposition: SummaryDispositionPolicy::KeepAll,
-                remote_keep_policy: RemoteCompactedHistoryKeepPolicy::KeepAll,
-                drop_prior_artifact_kinds: vec![],
-                legacy_compaction_marker_policy:
-                    LegacyCompactionMarkerPolicy::PreserveForUpstreamCompatibility,
-            },
-        });
+        let result =
+            apply_history_disposition_without_summary_retention(HistoryDispositionRequest {
+                items: vec![marker.clone()],
+                policy: HistoryDispositionPolicy {
+                    prune_superseded_artifacts: false,
+                    summary_disposition: SummaryDispositionPolicy::KeepAll,
+                    remote_keep_policy: RemoteCompactedHistoryKeepPolicy::KeepAll,
+                    drop_prior_artifact_kinds: vec![],
+                    legacy_compaction_marker_policy:
+                        LegacyCompactionMarkerPolicy::PreserveForUpstreamCompatibility,
+                },
+            });
 
         assert_eq!(
             result,
@@ -535,7 +534,7 @@ mod tests {
 
     #[test]
     fn apply_history_disposition_keeps_only_latest_compaction_summary_when_requested() {
-        let result = apply_history_disposition_with_summary_classifier(
+        let result = apply_history_disposition(
             HistoryDispositionRequest {
                 items: vec![
                     summary_message("older summary"),

--- a/codex-rs/context-maintenance-policy/src/history_shape.rs
+++ b/codex-rs/context-maintenance-policy/src/history_shape.rs
@@ -6,7 +6,7 @@ use crate::HistoryDispositionRequest;
 use crate::RemoteCompactedHistoryKeepPolicy;
 use crate::RetentionDirective;
 use crate::apply_retention_directive;
-use crate::artifact_codecs::apply_history_disposition_with_summary_classifier;
+use crate::artifact_codecs::apply_history_disposition;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RemoteCompactedHistoryShapeRequest {
@@ -108,7 +108,7 @@ where
     FSummary: Fn(&ResponseItem) -> bool,
     FRawConversation: Fn(&ResponseItem) -> bool,
 {
-    let disposition = apply_history_disposition_with_summary_classifier(
+    let disposition = apply_history_disposition(
         HistoryDispositionRequest {
             items: request.compacted_history,
             policy: request.history_disposition.clone(),

--- a/codex-rs/context-maintenance-policy/src/lib.rs
+++ b/codex-rs/context-maintenance-policy/src/lib.rs
@@ -7,7 +7,6 @@ mod route_matrix;
 mod thread_memory;
 
 pub use artifact_codecs::apply_history_disposition;
-pub use artifact_codecs::apply_history_disposition_with_summary_classifier;
 pub use artifact_codecs::build_prune_manifest_item;
 pub use continuation_bridge::BridgeVariant;
 pub use continuation_bridge::ContinuationBridgeModelInput;

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -620,12 +620,12 @@ pub(crate) fn assemble_local_compacted_replacement_history(
         is_raw_conversation_message,
     )
     .items;
-    let ghost_snapshots: Vec<ResponseItem> = history_items
-        .iter()
-        .filter(|item| matches!(item, ResponseItem::GhostSnapshot { .. }))
-        .cloned()
-        .collect();
-    new_history.extend(ghost_snapshots);
+    new_history.extend(
+        history_items
+            .iter()
+            .filter(|item| matches!(item, ResponseItem::GhostSnapshot { .. }))
+            .cloned(),
+    );
     new_history
 }
 

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -26,6 +26,7 @@ use codex_analytics::CompactionStrategy;
 use codex_analytics::CompactionTrigger;
 use codex_analytics::now_unix_seconds;
 use codex_context_maintenance_policy::ArtifactKind;
+use codex_context_maintenance_policy::RetentionDirective;
 use codex_context_maintenance_policy::apply_retention_directive;
 use codex_context_maintenance_policy::insert_initial_context_before_last_real_user_or_summary as insert_initial_context_before_last_real_user_or_summary_impl;
 use codex_context_maintenance_policy::insert_items_before_last_summary_or_compaction as insert_items_before_last_summary_or_compaction_impl;
@@ -311,32 +312,21 @@ async fn run_compact_task_inner_impl(
     let summary_text = format!("{SUMMARY_PREFIX}\n{summary_suffix}");
     let user_messages = collect_user_messages(history_items);
 
-    let mut new_history = build_compacted_history(Vec::new(), &user_messages, &summary_text);
-
-    if matches!(
+    let initial_context = match injection_placement {
+        InitialContextInjection::DoNotInject => None,
+        InitialContextInjection::BeforeLastRealUserOrSummary => {
+            Some(sess.build_initial_context(turn_context.as_ref()).await)
+        }
+    };
+    let new_history = assemble_local_compacted_replacement_history(
+        history_items,
+        &user_messages,
+        &summary_text,
+        initial_context,
+        authoritative_items,
         injection_placement,
-        InitialContextInjection::BeforeLastRealUserOrSummary
-    ) {
-        let initial_context = sess.build_initial_context(turn_context.as_ref()).await;
-        new_history =
-            insert_initial_context_before_last_real_user_or_summary(new_history, initial_context);
-    }
-    if !authoritative_items.is_empty() {
-        new_history =
-            insert_items_before_last_summary_or_compaction(new_history, authoritative_items);
-    }
-    new_history = apply_retention_directive(
-        new_history,
         runtime_plan.retention_directive(),
-        is_raw_conversation_message,
-    )
-    .items;
-    let ghost_snapshots: Vec<ResponseItem> = history_items
-        .iter()
-        .filter(|item| matches!(item, ResponseItem::GhostSnapshot { .. }))
-        .cloned()
-        .collect();
-    new_history.extend(ghost_snapshots);
+    );
     let reference_context_item = match injection_placement {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastRealUserOrSummary => {
@@ -599,6 +589,44 @@ fn build_compacted_history_with_limit(
     });
 
     history
+}
+
+pub(crate) fn assemble_local_compacted_replacement_history(
+    history_items: &[ResponseItem],
+    user_messages: &[String],
+    summary_text: &str,
+    initial_context: Option<Vec<ResponseItem>>,
+    authoritative_items: Vec<ResponseItem>,
+    injection_placement: InitialContextInjection,
+    retention_directive: RetentionDirective,
+) -> Vec<ResponseItem> {
+    let mut new_history = build_compacted_history(Vec::new(), user_messages, summary_text);
+
+    if matches!(
+        injection_placement,
+        InitialContextInjection::BeforeLastRealUserOrSummary
+    ) && let Some(initial_context) = initial_context
+    {
+        new_history =
+            insert_initial_context_before_last_real_user_or_summary(new_history, initial_context);
+    }
+    if !authoritative_items.is_empty() {
+        new_history =
+            insert_items_before_last_summary_or_compaction(new_history, authoritative_items);
+    }
+    new_history = apply_retention_directive(
+        new_history,
+        retention_directive,
+        is_raw_conversation_message,
+    )
+    .items;
+    let ghost_snapshots: Vec<ResponseItem> = history_items
+        .iter()
+        .filter(|item| matches!(item, ResponseItem::GhostSnapshot { .. }))
+        .cloned()
+        .collect();
+    new_history.extend(ghost_snapshots);
+    new_history
 }
 
 async fn drain_to_completed(

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -1,10 +1,14 @@
 use super::*;
+use crate::config::GovernancePathVariant;
 use crate::content_items_to_text;
+use crate::context_maintenance_runtime::CompactInvocationTiming;
 use crate::context_maintenance_runtime::compaction_engine;
+use crate::context_maintenance_runtime::live_compact_route_behavior_for_tests;
 use codex_context_maintenance_policy::HistoryDispositionPolicy;
 use codex_context_maintenance_policy::RemoteCompactedHistoryKeepPolicy;
 use codex_context_maintenance_policy::RetentionDirective;
 use codex_context_maintenance_policy::SummaryDispositionPolicy;
+use codex_git_utils::GhostCommit;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
 
@@ -391,6 +395,200 @@ fn build_token_limited_compacted_history_appends_summary_message() {
         other => panic!("expected summary message, found {other:?}"),
     };
     assert_eq!(summary, summary_text);
+}
+
+fn developer_message(text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "developer".to_string(),
+        content: vec![ContentItem::InputText {
+            text: text.to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }
+}
+
+fn user_message(text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: text.to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }
+}
+
+fn assistant_message(text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "assistant".to_string(),
+        content: vec![ContentItem::OutputText {
+            text: text.to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }
+}
+
+fn summary_message(text: &str) -> String {
+    format!("{SUMMARY_PREFIX}\n{text}")
+}
+
+#[test]
+fn local_intra_turn_compact_drops_prior_bridge_by_construction() {
+    let runtime_plan = live_compact_route_behavior_for_tests(
+        CompactionEngine::LocalPure,
+        GovernancePathVariant::StrictV1Shadow,
+        CompactInvocationTiming::IntraTurn,
+    );
+    let raw_history = vec![
+        user_message("older user"),
+        assistant_message("older assistant"),
+        developer_message("<continuation_bridge>old-bridge</continuation_bridge>"),
+        ResponseItem::Compaction {
+            encrypted_content: "encrypted".to_string(),
+        },
+        ResponseItem::GhostSnapshot {
+            ghost_commit: GhostCommit::new(
+                "ghost-1".to_string(),
+                /*parent*/ None,
+                Vec::new(),
+                Vec::new(),
+            ),
+        },
+    ];
+    let user_messages = collect_user_messages(&raw_history);
+    let new_bridge = developer_message("<continuation_bridge>new-bridge</continuation_bridge>");
+    let summary_text = summary_message("new summary");
+
+    let replacement_history = assemble_local_compacted_replacement_history(
+        &raw_history,
+        &user_messages,
+        &summary_text,
+        Some(vec![developer_message("fresh initial context")]),
+        vec![new_bridge],
+        runtime_plan.context_injection_placement(),
+        runtime_plan.retention_directive(),
+    );
+
+    let replacement_texts: Vec<_> = replacement_history
+        .iter()
+        .filter_map(|item| match item {
+            ResponseItem::Message { content, .. } => content_items_to_text(content),
+            _ => None,
+        })
+        .collect();
+    let summary_index = replacement_texts
+        .iter()
+        .position(|text| text == &summary_text)
+        .expect("summary should be present");
+    let new_bridge_index = replacement_texts
+        .iter()
+        .position(|text| text.contains("new-bridge"))
+        .expect("new bridge should be present");
+    let initial_context_index = replacement_texts
+        .iter()
+        .position(|text| text == "fresh initial context")
+        .expect("initial context should be present");
+    let latest_user_index = replacement_texts
+        .iter()
+        .position(|text| text == "older user")
+        .expect("user message should be preserved");
+
+    assert!(
+        !replacement_texts
+            .iter()
+            .any(|text| text.contains("old-bridge")),
+        "prior continuation bridge should be dropped"
+    );
+    assert!(
+        !replacement_history
+            .iter()
+            .any(|item| matches!(item, ResponseItem::Compaction { .. })),
+        "local compact should strip legacy compaction markers"
+    );
+    assert!(new_bridge_index < summary_index);
+    assert!(initial_context_index < latest_user_index);
+    assert!(matches!(
+        replacement_history.last(),
+        Some(ResponseItem::GhostSnapshot { .. })
+    ));
+}
+
+#[test]
+fn local_turn_boundary_compact_drops_prior_memory_and_bridge_by_construction() {
+    let runtime_plan = live_compact_route_behavior_for_tests(
+        CompactionEngine::LocalPure,
+        GovernancePathVariant::StrictV1Shadow,
+        CompactInvocationTiming::TurnBoundary,
+    );
+    let raw_history = vec![
+        user_message("older user"),
+        assistant_message("older assistant"),
+        developer_message("<thread_memory>old-memory</thread_memory>"),
+        developer_message("<continuation_bridge>old-bridge</continuation_bridge>"),
+        ResponseItem::Compaction {
+            encrypted_content: "encrypted".to_string(),
+        },
+    ];
+    let user_messages = collect_user_messages(&raw_history);
+    let new_memory = developer_message("<thread_memory>new-memory</thread_memory>");
+    let summary_text = summary_message("turn boundary summary");
+
+    let replacement_history = assemble_local_compacted_replacement_history(
+        &raw_history,
+        &user_messages,
+        &summary_text,
+        None,
+        vec![new_memory],
+        runtime_plan.context_injection_placement(),
+        runtime_plan.retention_directive(),
+    );
+
+    let replacement_texts: Vec<_> = replacement_history
+        .iter()
+        .filter_map(|item| match item {
+            ResponseItem::Message { content, .. } => content_items_to_text(content),
+            _ => None,
+        })
+        .collect();
+    let summary_index = replacement_texts
+        .iter()
+        .position(|text| text == &summary_text)
+        .expect("summary should be present");
+    let new_memory_index = replacement_texts
+        .iter()
+        .position(|text| text.contains("new-memory"))
+        .expect("new thread memory should be present");
+
+    assert!(
+        !replacement_texts
+            .iter()
+            .any(|text| text.contains("old-memory")),
+        "prior thread memory should be dropped"
+    );
+    assert!(
+        !replacement_texts
+            .iter()
+            .any(|text| text.contains("old-bridge")),
+        "prior continuation bridge should be dropped"
+    );
+    assert!(
+        !replacement_texts
+            .iter()
+            .any(|text| text == "fresh initial context"),
+        "turn-boundary compact should not inject initial context"
+    );
+    assert!(
+        !replacement_history
+            .iter()
+            .any(|item| matches!(item, ResponseItem::Compaction { .. })),
+        "local compact should strip legacy compaction markers"
+    );
+    assert!(new_memory_index < summary_index);
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/context_maintenance.rs
+++ b/codex-rs/core/src/context_maintenance.rs
@@ -10,7 +10,6 @@ use crate::governance::thread_memory::generate_thread_memory_item;
 use codex_context_maintenance_policy::ArtifactKind;
 use codex_context_maintenance_policy::MaintenanceAction;
 use codex_context_maintenance_policy::apply_history_disposition;
-use codex_context_maintenance_policy::apply_history_disposition_with_summary_classifier;
 use codex_context_maintenance_policy::apply_retention_directive;
 use codex_context_maintenance_policy::build_prune_manifest_item;
 use codex_protocol::error::Result as CodexResult;
@@ -52,8 +51,10 @@ pub(crate) async fn run_refresh(
     )
     .await?;
 
-    let disposition =
-        apply_history_disposition(runtime_plan.history_disposition_request(raw_history));
+    let disposition = apply_history_disposition(
+        runtime_plan.history_disposition_request(raw_history),
+        is_compaction_summary_message,
+    );
     let mut new_history = disposition.items;
     let mut removed_count = disposition.removed_count;
 
@@ -104,7 +105,7 @@ pub(crate) async fn run_prune(
     let raw_history = history_snapshot.raw_items().to_vec();
 
     let original_len = raw_history.len();
-    let disposition = apply_history_disposition_with_summary_classifier(
+    let disposition = apply_history_disposition(
         runtime_plan.history_disposition_request(raw_history),
         is_compaction_summary_message,
     );
@@ -189,7 +190,7 @@ mod tests {
 
     #[test]
     fn prune_removes_all_but_latest_prune_manifest() {
-        let result = apply_history_disposition_with_summary_classifier(
+        let result = apply_history_disposition(
             HistoryDispositionRequest {
                 items: vec![
                     developer_message("<prune_manifest>old</prune_manifest>"),
@@ -223,7 +224,7 @@ mod tests {
             user_summary_message("latest summary"),
         ];
 
-        let result = apply_history_disposition_with_summary_classifier(
+        let result = apply_history_disposition(
             HistoryDispositionRequest {
                 items: raw_history,
                 policy: HistoryDispositionPolicy {


### PR DESCRIPTION
## Summary
- make the classifier-aware history disposition executor the single public production path
- extract a deterministic local replacement-history assembler for local compact
- add local compact invariant tests for stale artifact dropping, authoritative artifact placement, and marker stripping

## Validation
- cargo test -p codex-context-maintenance-policy
- cargo test -p codex-core compact::tests --lib
- cargo test -p codex-core context_maintenance --lib
- cargo check -p codex-core
- just fix -p codex-context-maintenance-policy
- just fix -p codex-core
- just fmt
