### PR TITLE
[codex] Make session progress observation explicit

### DIFF
--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -1,6 +1,7 @@
 use crate::client::ModelClient;
 use crate::realtime_context::build_realtime_startup_context;
 use crate::realtime_prompt::prepare_realtime_backend_prompt;
+use crate::session::ProgressObservation;
 use crate::session::session::Session;
 use anyhow::Context;
 use async_channel::Receiver;
@@ -562,12 +563,17 @@ pub(crate) async fn handle_start(
         Err(err) => {
             error!("failed to prepare realtime conversation: {err}");
             let message = err.to_string();
-            sess.send_event_raw(Event {
-                id: sub_id,
-                msg: EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
-                    payload: RealtimeEvent::Error(message),
-                }),
-            })
+            sess.send_event_raw(
+                Event {
+                    id: sub_id,
+                    msg: EventMsg::RealtimeConversationRealtime(
+                        RealtimeConversationRealtimeEvent {
+                            payload: RealtimeEvent::Error(message),
+                        },
+                    ),
+                },
+                ProgressObservation::Observe,
+            )
             .await;
             return Ok(());
         }
@@ -576,12 +582,15 @@ pub(crate) async fn handle_start(
     if let Err(err) = handle_start_inner(sess, &sub_id, prepared_start).await {
         error!("failed to start realtime conversation: {err}");
         let message = err.to_string();
-        sess.send_event_raw(Event {
-            id: sub_id.clone(),
-            msg: EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
-                payload: RealtimeEvent::Error(message),
-            }),
-        })
+        sess.send_event_raw(
+            Event {
+                id: sub_id.clone(),
+                msg: EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
+                    payload: RealtimeEvent::Error(message),
+                }),
+            },
+            ProgressObservation::Observe,
+        )
         .await;
     }
     Ok(())
@@ -782,13 +791,16 @@ async fn handle_start_inner(
 
     info!("realtime conversation started");
 
-    sess.send_event_raw(Event {
-        id: sub_id.to_string(),
-        msg: EventMsg::RealtimeConversationStarted(RealtimeConversationStartedEvent {
-            session_id: requested_session_id,
-            version,
-        }),
-    })
+    sess.send_event_raw(
+        Event {
+            id: sub_id.to_string(),
+            msg: EventMsg::RealtimeConversationStarted(RealtimeConversationStartedEvent {
+                session_id: requested_session_id,
+                version,
+            }),
+        },
+        ProgressObservation::Observe,
+    )
     .await;
 
     let RealtimeStartOutput {
@@ -797,10 +809,13 @@ async fn handle_start_inner(
         sdp,
     } = start_output;
     if let Some(sdp) = sdp {
-        sess.send_event_raw(Event {
-            id: sub_id.to_string(),
-            msg: EventMsg::RealtimeConversationSdp(RealtimeConversationSdpEvent { sdp }),
-        })
+        sess.send_event_raw(
+            Event {
+                id: sub_id.to_string(),
+                msg: EventMsg::RealtimeConversationSdp(RealtimeConversationSdpEvent { sdp }),
+            },
+            ProgressObservation::Observe,
+        )
         .await;
     }
 
@@ -846,11 +861,14 @@ async fn handle_start_inner(
                 break;
             }
             sess_clone
-                .send_event_raw(ev(EventMsg::RealtimeConversationRealtime(
-                    RealtimeConversationRealtimeEvent {
-                        payload: event.clone(),
-                    },
-                )))
+                .send_event_raw(
+                    ev(EventMsg::RealtimeConversationRealtime(
+                        RealtimeConversationRealtimeEvent {
+                            payload: event.clone(),
+                        },
+                    )),
+                    ProgressObservation::Observe,
+                )
                 .await;
         }
         if fanout_realtime_active.swap(false, Ordering::Relaxed) {
@@ -1367,13 +1385,16 @@ async fn send_conversation_error(
     message: String,
     codex_error_info: CodexErrorInfo,
 ) {
-    sess.send_event_raw(Event {
-        id: sub_id,
-        msg: EventMsg::Error(ErrorEvent {
-            message,
-            codex_error_info: Some(codex_error_info),
-        }),
-    })
+    sess.send_event_raw(
+        Event {
+            id: sub_id,
+            msg: EventMsg::Error(ErrorEvent {
+                message,
+                codex_error_info: Some(codex_error_info),
+            }),
+        },
+        ProgressObservation::Observe,
+    )
     .await;
 }
 
@@ -1397,10 +1418,13 @@ async fn send_realtime_conversation_closed(
         RealtimeConversationEnd::Error => Some("error".to_string()),
     };
 
-    sess.send_event_raw(Event {
-        id: sub_id,
-        msg: EventMsg::RealtimeConversationClosed(RealtimeConversationClosedEvent { reason }),
-    })
+    sess.send_event_raw(
+        Event {
+            id: sub_id,
+            msg: EventMsg::RealtimeConversationClosed(RealtimeConversationClosedEvent { reason }),
+        },
+        ProgressObservation::Observe,
+    )
     .await;
 }
 

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -9,6 +9,7 @@ use tracing::Instrument;
 use tracing::debug_span;
 use tracing::info_span;
 
+use crate::session::ProgressObservation;
 use crate::session::SteerInputError;
 use crate::session::session::Session;
 use crate::session::session::SessionSettingsUpdate;
@@ -87,26 +88,32 @@ pub async fn clean_background_terminals(sess: &Arc<Session>) {
 }
 
 pub async fn realtime_conversation_list_voices(sess: &Session, sub_id: String) {
-    sess.send_event_raw(Event {
-        id: sub_id,
-        msg: EventMsg::RealtimeConversationListVoicesResponse(
-            RealtimeConversationListVoicesResponseEvent {
-                voices: RealtimeVoicesList::builtin(),
-            },
-        ),
-    })
+    sess.send_event_raw(
+        Event {
+            id: sub_id,
+            msg: EventMsg::RealtimeConversationListVoicesResponse(
+                RealtimeConversationListVoicesResponseEvent {
+                    voices: RealtimeVoicesList::builtin(),
+                },
+            ),
+        },
+        ProgressObservation::Observe,
+    )
     .await;
 }
 
 pub async fn override_turn_context(sess: &Session, sub_id: String, updates: SessionSettingsUpdate) {
     if let Err(err) = sess.update_settings(updates).await {
-        sess.send_event_raw(Event {
-            id: sub_id,
-            msg: EventMsg::Error(ErrorEvent {
-                message: err.to_string(),
-                codex_error_info: Some(CodexErrorInfo::BadRequest),
-            }),
-        })
+        sess.send_event_raw(
+            Event {
+                id: sub_id,
+                msg: EventMsg::Error(ErrorEvent {
+                    message: err.to_string(),
+                    codex_error_info: Some(CodexErrorInfo::BadRequest),
+                }),
+            },
+            ProgressObservation::Observe,
+        )
         .await;
     }
 }
@@ -223,10 +230,13 @@ pub(super) async fn user_input_or_turn_inner(
             Some(accepted_items)
         }
         Err(err) => {
-            sess.send_event_raw(Event {
-                id: sub_id,
-                msg: EventMsg::Error(err.to_error_event()),
-            })
+            sess.send_event_raw(
+                Event {
+                    id: sub_id,
+                    msg: EventMsg::Error(err.to_error_event()),
+                },
+                ProgressObservation::Observe,
+            )
             .await;
             None
         }
@@ -368,10 +378,13 @@ pub async fn exec_approval(
                 let message = format!("Failed to apply execpolicy amendment: {err}");
                 tracing::warn!("{message}");
                 let warning = EventMsg::Warning(WarningEvent { message });
-                sess.send_event_raw(Event {
-                    id: event_turn_id.clone(),
-                    msg: warning,
-                })
+                sess.send_event_raw(
+                    Event {
+                        id: event_turn_id.clone(),
+                        msg: warning,
+                    },
+                    ProgressObservation::Observe,
+                )
                 .await;
             }
         }
@@ -457,7 +470,9 @@ pub async fn get_history_entry_request(
             ),
         };
 
-        sess_clone.send_event_raw(event).await;
+        sess_clone
+            .send_event_raw(event, ProgressObservation::Observe)
+            .await;
     });
 }
 
@@ -487,7 +502,8 @@ pub async fn list_mcp_tools(sess: &Session, config: &Arc<Config>, sub_id: String
         id: sub_id,
         msg: EventMsg::McpListToolsResponse(snapshot),
     };
-    sess.send_event_raw(event).await;
+    sess.send_event_raw(event, ProgressObservation::Observe)
+        .await;
 }
 
 pub async fn list_skills(sess: &Session, sub_id: String, cwds: Vec<PathBuf>, force_reload: bool) {
@@ -580,7 +596,8 @@ pub async fn list_skills(sess: &Session, sub_id: String, cwds: Vec<PathBuf>, for
         id: sub_id,
         msg: EventMsg::ListSkillsResponse(ListSkillsResponseEvent { skills }),
     };
-    sess.send_event_raw(event).await;
+    sess.send_event_raw(event, ProgressObservation::Observe)
+        .await;
 }
 
 pub async fn undo(sess: &Arc<Session>, sub_id: String) {
@@ -644,26 +661,32 @@ pub async fn drop_memories(sess: &Arc<Session>, config: &Arc<Config>, sub_id: St
 
     if errors.is_empty() {
         let memory_root = crate::memories::memory_root(&config.codex_home);
-        sess.send_event_raw(Event {
-            id: sub_id,
-            msg: EventMsg::Warning(WarningEvent {
-                message: format!(
-                    "Dropped memories at {} and cleared memory rows from state db.",
-                    memory_root.display()
-                ),
-            }),
-        })
+        sess.send_event_raw(
+            Event {
+                id: sub_id,
+                msg: EventMsg::Warning(WarningEvent {
+                    message: format!(
+                        "Dropped memories at {} and cleared memory rows from state db.",
+                        memory_root.display()
+                    ),
+                }),
+            },
+            ProgressObservation::Observe,
+        )
         .await;
         return;
     }
 
-    sess.send_event_raw(Event {
-        id: sub_id,
-        msg: EventMsg::Error(ErrorEvent {
-            message: format!("Memory drop completed with errors: {}", errors.join("; ")),
-            codex_error_info: Some(CodexErrorInfo::Other),
-        }),
-    })
+    sess.send_event_raw(
+        Event {
+            id: sub_id,
+            msg: EventMsg::Error(ErrorEvent {
+                message: format!("Memory drop completed with errors: {}", errors.join("; ")),
+                codex_error_info: Some(CodexErrorInfo::Other),
+            }),
+        },
+        ProgressObservation::Observe,
+    )
     .await;
 }
 
@@ -675,37 +698,46 @@ pub async fn update_memories(sess: &Arc<Session>, config: &Arc<Config>, sub_id: 
 
     crate::memories::start_memories_startup_task(sess, Arc::clone(config), &session_source);
 
-    sess.send_event_raw(Event {
-        id: sub_id.clone(),
-        msg: EventMsg::Warning(WarningEvent {
-            message: "Memory update triggered.".to_string(),
-        }),
-    })
+    sess.send_event_raw(
+        Event {
+            id: sub_id.clone(),
+            msg: EventMsg::Warning(WarningEvent {
+                message: "Memory update triggered.".to_string(),
+            }),
+        },
+        ProgressObservation::Observe,
+    )
     .await;
 }
 
 pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32) {
     if num_turns == 0 {
-        sess.send_event_raw(Event {
-            id: sub_id,
-            msg: EventMsg::Error(ErrorEvent {
-                message: "num_turns must be >= 1".to_string(),
-                codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
-            }),
-        })
+        sess.send_event_raw(
+            Event {
+                id: sub_id,
+                msg: EventMsg::Error(ErrorEvent {
+                    message: "num_turns must be >= 1".to_string(),
+                    codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
+                }),
+            },
+            ProgressObservation::Observe,
+        )
         .await;
         return;
     }
 
     let has_active_turn = { sess.active_turn.lock().await.is_some() };
     if has_active_turn {
-        sess.send_event_raw(Event {
-            id: sub_id,
-            msg: EventMsg::Error(ErrorEvent {
-                message: "Cannot rollback while a turn is in progress.".to_string(),
-                codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
-            }),
-        })
+        sess.send_event_raw(
+            Event {
+                id: sub_id,
+                msg: EventMsg::Error(ErrorEvent {
+                    message: "Cannot rollback while a turn is in progress.".to_string(),
+                    codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
+                }),
+            },
+            ProgressObservation::Observe,
+        )
         .await;
         return;
     }
@@ -717,13 +749,16 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
             guard.clone()
         };
         let Some(recorder) = recorder else {
-            sess.send_event_raw(Event {
-                id: turn_context.sub_id.clone(),
-                msg: EventMsg::Error(ErrorEvent {
-                    message: "thread rollback requires a persisted rollout path".to_string(),
-                    codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
-                }),
-            })
+            sess.send_event_raw(
+                Event {
+                    id: turn_context.sub_id.clone(),
+                    msg: EventMsg::Error(ErrorEvent {
+                        message: "thread rollback requires a persisted rollout path".to_string(),
+                        codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
+                    }),
+                },
+                ProgressObservation::Observe,
+            )
             .await;
             return;
         };
@@ -734,16 +769,19 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
         guard.clone()
     } && let Err(err) = recorder.flush().await
     {
-        sess.send_event_raw(Event {
-            id: turn_context.sub_id.clone(),
-            msg: EventMsg::Error(ErrorEvent {
-                message: format!(
-                    "failed to flush rollout `{}` for rollback replay: {err}",
-                    rollout_path.display()
-                ),
-                codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
-            }),
-        })
+        sess.send_event_raw(
+            Event {
+                id: turn_context.sub_id.clone(),
+                msg: EventMsg::Error(ErrorEvent {
+                    message: format!(
+                        "failed to flush rollout `{}` for rollback replay: {err}",
+                        rollout_path.display()
+                    ),
+                    codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
+                }),
+            },
+            ProgressObservation::Observe,
+        )
         .await;
         return;
     }
@@ -751,16 +789,19 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
     let initial_history = match RolloutRecorder::get_rollout_history(rollout_path.as_path()).await {
         Ok(history) => history,
         Err(err) => {
-            sess.send_event_raw(Event {
-                id: turn_context.sub_id.clone(),
-                msg: EventMsg::Error(ErrorEvent {
-                    message: format!(
-                        "failed to load rollout `{}` for rollback replay: {err}",
-                        rollout_path.display()
-                    ),
-                    codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
-                }),
-            })
+            sess.send_event_raw(
+                Event {
+                    id: turn_context.sub_id.clone(),
+                    msg: EventMsg::Error(ErrorEvent {
+                        message: format!(
+                            "failed to load rollout `{}` for rollback replay: {err}",
+                            rollout_path.display()
+                        ),
+                        codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
+                    }),
+                },
+                ProgressObservation::Observe,
+            )
             .await;
             return;
         }
@@ -791,10 +832,13 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
         .await;
     }
 
-    sess.deliver_event_raw(Event {
-        id: turn_context.sub_id.clone(),
-        msg: rollback_msg,
-    })
+    sess.deliver_event_raw(
+        Event {
+            id: turn_context.sub_id.clone(),
+            msg: rollback_msg,
+        },
+        ProgressObservation::Observe,
+    )
     .await;
 }
 
@@ -863,7 +907,8 @@ pub async fn set_thread_name(sess: &Arc<Session>, sub_id: String, name: String) 
                 codex_error_info: Some(CodexErrorInfo::BadRequest),
             }),
         };
-        sess.send_event_raw(event).await;
+        sess.send_event_raw(event, ProgressObservation::Observe)
+            .await;
         return;
     };
 
@@ -883,7 +928,8 @@ pub async fn set_thread_name(sess: &Arc<Session>, sub_id: String, name: String) 
                     codex_error_info: Some(CodexErrorInfo::Other),
                 }),
             };
-            sess.send_event_raw(event).await;
+            sess.send_event_raw(event, ProgressObservation::Observe)
+                .await;
             return;
         }
     };
@@ -908,7 +954,8 @@ pub async fn set_thread_name(sess: &Arc<Session>, sub_id: String, name: String) 
         warn!("Failed to update legacy thread name index: {err}");
     }
 
-    sess.deliver_event_raw(Event { id: sub_id, msg }).await;
+    sess.deliver_event_raw(Event { id: sub_id, msg }, ProgressObservation::Observe)
+        .await;
 }
 
 /// Persists thread-level memory mode metadata for the active session.
@@ -925,7 +972,8 @@ pub async fn set_thread_memory_mode(sess: &Arc<Session>, sub_id: String, mode: T
                 codex_error_info: Some(CodexErrorInfo::Other),
             }),
         };
-        sess.send_event_raw(event).await;
+        sess.send_event_raw(event, ProgressObservation::Observe)
+            .await;
     }
 }
 
@@ -967,14 +1015,16 @@ pub async fn shutdown(sess: &Arc<Session>, sub_id: String) -> bool {
                 codex_error_info: Some(CodexErrorInfo::Other),
             }),
         };
-        sess.send_event_raw(event).await;
+        sess.send_event_raw(event, ProgressObservation::Observe)
+            .await;
     }
 
     let event = Event {
         id: sub_id,
         msg: EventMsg::ShutdownComplete,
     };
-    sess.send_event_raw(event).await;
+    sess.send_event_raw(event, ProgressObservation::Observe)
+        .await;
     true
 }
 
@@ -1035,13 +1085,16 @@ pub(super) async fn submission_loop(
                     if let Err(err) =
                         handle_realtime_conversation_start(&sess, sub.id.clone(), params).await
                     {
-                        sess.send_event_raw(Event {
-                            id: sub.id.clone(),
-                            msg: EventMsg::Error(ErrorEvent {
-                                message: err.to_string(),
-                                codex_error_info: Some(CodexErrorInfo::Other),
-                            }),
-                        })
+                        sess.send_event_raw(
+                            Event {
+                                id: sub.id.clone(),
+                                msg: EventMsg::Error(ErrorEvent {
+                                    message: err.to_string(),
+                                    codex_error_info: Some(CodexErrorInfo::Other),
+                                }),
+                            },
+                            ProgressObservation::Observe,
+                        )
                         .await;
                     }
                     false

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -792,6 +792,12 @@ pub(crate) fn session_loop_termination_from_handle(
     .shared()
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProgressObservation {
+    Observe,
+    CompatibilityOnly,
+}
+
 async fn thread_title_from_state_db(
     state_db: Option<&state_db::StateDbHandle>,
     codex_home: &AbsolutePathBuf,
@@ -962,7 +968,8 @@ impl Session {
                             id: sess.next_internal_sub_id(),
                             msg: EventMsg::SkillsUpdateAvailable,
                         };
-                        sess.send_event_raw(event).await;
+                        sess.send_event_raw(event, ProgressObservation::Observe)
+                            .await;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
@@ -1013,13 +1020,16 @@ impl Session {
         let message = format!(
             "Agent identity registration failed while `features.use_agent_identity` is enabled: {error}"
         );
-        self.send_event_raw(Event {
-            id: self.next_internal_sub_id(),
-            msg: EventMsg::Error(ErrorEvent {
-                message,
-                codex_error_info: Some(CodexErrorInfo::Other),
-            }),
-        })
+        self.send_event_raw(
+            Event {
+                id: self.next_internal_sub_id(),
+                msg: EventMsg::Error(ErrorEvent {
+                    message,
+                    codex_error_info: Some(CodexErrorInfo::Other),
+                }),
+            },
+            ProgressObservation::Observe,
+        )
         .await;
     }
 
@@ -1563,14 +1573,12 @@ impl Session {
     /// Persist the event to rollout and send it to clients.
     pub(crate) async fn send_event(&self, turn_context: &TurnContext, msg: EventMsg) {
         let legacy_source = msg.clone();
-        self.services
-            .agent_control
-            .record_progress_event(self.conversation_id, &legacy_source);
         let event = Event {
             id: turn_context.sub_id.clone(),
             msg,
         };
-        self.send_event_raw(event).await;
+        self.send_event_raw(event, ProgressObservation::Observe)
+            .await;
         self.maybe_notify_parent_of_terminal_turn(turn_context, &legacy_source)
             .await;
         self.maybe_mirror_event_text_to_realtime(&legacy_source)
@@ -1584,7 +1592,8 @@ impl Session {
                 id: turn_context.sub_id.clone(),
                 msg: legacy,
             };
-            self.send_event_raw(legacy_event).await;
+            self.send_event_raw(legacy_event, ProgressObservation::CompatibilityOnly)
+                .await;
         }
     }
 
@@ -1679,17 +1688,22 @@ impl Session {
         self.conversation.clear_active_handoff().await;
     }
 
-    pub(crate) async fn send_event_raw(&self, event: Event) {
+    pub(crate) async fn send_event_raw(&self, event: Event, observation: ProgressObservation) {
         // Persist the event into rollout (recorder filters as needed)
         let rollout_items = vec![RolloutItem::EventMsg(event.msg.clone())];
         self.persist_rollout_items(&rollout_items).await;
-        self.deliver_event_raw(event).await;
+        self.deliver_event_raw(event, observation).await;
     }
 
-    async fn deliver_event_raw(&self, event: Event) {
+    async fn deliver_event_raw(&self, event: Event, observation: ProgressObservation) {
         // Record the last known agent status.
         if let Some(status) = agent_status_from_event(&event.msg) {
             self.agent_status.send_replace(status);
+        }
+        if observation == ProgressObservation::Observe {
+            self.services
+                .agent_control
+                .record_progress_event(self.conversation_id, &event.msg);
         }
         if let Err(e) = self.tx_event.send(event).await {
             debug!("dropping event because channel is closed: {e}");
@@ -2498,12 +2512,15 @@ impl Session {
             );
             if let Some(rendered_skills) = rendered_skills {
                 if rendered_skills.emit_warning {
-                    self.send_event_raw(Event {
-                        id: String::new(),
-                        msg: EventMsg::Warning(WarningEvent {
-                            message: THREAD_START_SKILLS_TRIMMED_WARNING_MESSAGE.to_string(),
-                        }),
-                    })
+                    self.send_event_raw(
+                        Event {
+                            id: String::new(),
+                            msg: EventMsg::Warning(WarningEvent {
+                                message: THREAD_START_SKILLS_TRIMMED_WARNING_MESSAGE.to_string(),
+                            }),
+                        },
+                        ProgressObservation::Observe,
+                    )
                     .await;
                 }
                 runtime_sections.push(rendered_skills.text.clone());

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -745,7 +745,8 @@ impl Session {
         })
         .chain(post_session_configured_events.into_iter());
         for event in events {
-            sess.send_event_raw(event).await;
+            sess.send_event_raw(event, ProgressObservation::Observe)
+                .await;
         }
 
         // Start the watcher after SessionConfigured so it cannot emit earlier events.

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -498,13 +498,16 @@ impl Session {
         ) = match update_result {
             Ok(update) => update,
             Err(err) => {
-                self.send_event_raw(Event {
-                    id: sub_id.clone(),
-                    msg: EventMsg::Error(ErrorEvent {
-                        message: err.to_string(),
-                        codex_error_info: Some(CodexErrorInfo::BadRequest),
-                    }),
-                })
+                self.send_event_raw(
+                    Event {
+                        id: sub_id.clone(),
+                        msg: EventMsg::Error(ErrorEvent {
+                            message: err.to_string(),
+                            codex_error_info: Some(CodexErrorInfo::BadRequest),
+                        }),
+                    },
+                    ProgressObservation::Observe,
+                )
                 .await;
                 return Err(err);
             }

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -4,6 +4,7 @@ use crate::ThreadManager;
 use crate::config::AgentRoleConfig;
 use crate::config::DEFAULT_AGENT_MAX_DEPTH;
 use crate::function_tool::FunctionCallError;
+use crate::session::ProgressObservation;
 use crate::session::tests::make_session_and_context;
 use crate::session_prefix::format_subagent_notification_message;
 use crate::state::TaskKind;
@@ -27,19 +28,24 @@ use codex_model_provider::create_model_provider;
 use codex_model_provider_info::built_in_model_providers;
 use codex_protocol::AgentPath;
 use codex_protocol::ThreadId;
+use codex_protocol::items::TurnItem;
+use codex_protocol::items::WebSearchItem;
 use codex_protocol::models::BaseInstructions;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::FunctionCallOutputBody;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
+use codex_protocol::models::WebSearchAction;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::AgentReasoningEvent;
 use codex_protocol::protocol::AgentStatus;
 use codex_protocol::protocol::AskForApproval;
+use codex_protocol::protocol::ErrorEvent;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::FileSystemSandboxPolicy;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
+use codex_protocol::protocol::ItemStartedEvent;
 use codex_protocol::protocol::NetworkSandboxPolicy;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RolloutItem;
@@ -49,6 +55,8 @@ use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TurnAbortReason;
 use codex_protocol::protocol::TurnAbortedEvent;
 use codex_protocol::protocol::TurnCompleteEvent;
+use codex_protocol::protocol::TurnStartedEvent;
+use codex_protocol::protocol::WarningEvent;
 use codex_protocol::user_input::UserInput;
 use core_test_support::TempDirExt;
 use pretty_assertions::assert_eq;
@@ -93,6 +101,22 @@ fn thread_manager() -> ThreadManager {
         CodexAuth::from_api_key("dummy"),
         built_in_model_providers(/* openai_base_url */ /*openai_base_url*/ None)["openai"].clone(),
     )
+}
+
+async fn manager_backed_session_and_turn() -> (
+    Arc<crate::session::session::Session>,
+    Arc<TurnContext>,
+    ThreadManager,
+) {
+    let (_session, turn) = make_session_and_context().await;
+    let manager = thread_manager();
+    let root = manager
+        .start_thread((*turn.config).clone())
+        .await
+        .expect("root thread should start");
+    let session: Arc<crate::session::session::Session> = Arc::clone(&root.thread.codex.session);
+    let turn = session.new_default_turn().await;
+    (session, turn, manager)
 }
 
 async fn install_role_with_model_override(turn: &mut TurnContext) -> String {
@@ -1486,6 +1510,200 @@ async fn wait_for_agent_progress_returns_on_material_progress() {
     assert_eq!(result["ever_reported_progress"], json!(true));
     assert_eq!(result["seq"], json!(1));
     assert_eq!(success, Some(true));
+}
+
+#[tokio::test]
+async fn session_send_event_observes_primary_item_started_once_with_legacy_echoes() {
+    let (session, turn, _manager) = manager_backed_session_and_turn().await;
+    let mut progress_seq_rx = session
+        .services
+        .agent_control
+        .subscribe_progress_seq(session.conversation_id)
+        .await
+        .expect("progress seq subscription should succeed");
+
+    session
+        .send_event(
+            turn.as_ref(),
+            EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: turn.sub_id.clone(),
+                started_at: None,
+                model_context_window: Some(256_000),
+                collaboration_mode_kind: Default::default(),
+            }),
+        )
+        .await;
+
+    session
+        .send_event(
+            turn.as_ref(),
+            EventMsg::ItemStarted(ItemStartedEvent {
+                thread_id: session.conversation_id,
+                turn_id: turn.sub_id.clone(),
+                item: TurnItem::WebSearch(WebSearchItem {
+                    id: "search-1".to_string(),
+                    query: "find docs".to_string(),
+                    action: WebSearchAction::Search {
+                        query: Some("find docs".to_string()),
+                        queries: None,
+                    },
+                }),
+            }),
+        )
+        .await;
+
+    timeout(Duration::from_secs(1), progress_seq_rx.changed())
+        .await
+        .expect("primary event should advance the progress seq")
+        .expect("progress receiver should remain open");
+    assert_eq!(*progress_seq_rx.borrow(), 1);
+    assert!(
+        timeout(Duration::from_millis(50), progress_seq_rx.changed())
+            .await
+            .is_err()
+    );
+
+    let snapshot = session
+        .services
+        .agent_control
+        .inspect_agent_progress(session.conversation_id, Duration::from_millis(100))
+        .await;
+    assert_eq!(
+        snapshot.phase,
+        codex_agent_observability::AgentProgressPhase::ToolCall
+    );
+    assert_eq!(snapshot.seq, 1);
+    assert_eq!(
+        snapshot.active_work,
+        Some(codex_agent_observability::AgentActiveWork {
+            kind: codex_agent_observability::AgentActiveWorkKind::Tool,
+            label: "web_search".to_string(),
+        })
+    );
+}
+
+#[tokio::test]
+async fn observed_raw_error_updates_terminal_progress_state() {
+    let (session, _turn, _manager) = manager_backed_session_and_turn().await;
+    let mut progress_seq_rx = session
+        .services
+        .agent_control
+        .subscribe_progress_seq(session.conversation_id)
+        .await
+        .expect("progress seq subscription should succeed");
+
+    session
+        .send_event_raw(
+            codex_protocol::protocol::Event {
+                id: "raw-error".to_string(),
+                msg: EventMsg::Error(ErrorEvent {
+                    message: "boom".to_string(),
+                    codex_error_info: Some(codex_protocol::protocol::CodexErrorInfo::Other),
+                }),
+            },
+            ProgressObservation::Observe,
+        )
+        .await;
+
+    timeout(Duration::from_secs(1), progress_seq_rx.changed())
+        .await
+        .expect("raw error should advance progress seq")
+        .expect("progress receiver should remain open");
+    assert_eq!(*progress_seq_rx.borrow(), 1);
+
+    let snapshot = session
+        .services
+        .agent_control
+        .inspect_agent_progress(session.conversation_id, Duration::from_millis(100))
+        .await;
+    assert_eq!(
+        snapshot.phase,
+        codex_agent_observability::AgentProgressPhase::Errored
+    );
+    assert_eq!(
+        snapshot.lifecycle_status,
+        AgentStatus::Errored("boom".to_string())
+    );
+    assert_eq!(snapshot.error_message.as_deref(), Some("boom"));
+}
+
+#[tokio::test]
+async fn observed_raw_shutdown_complete_updates_terminal_progress_state() {
+    let (session, _turn, _manager) = manager_backed_session_and_turn().await;
+    let mut progress_seq_rx = session
+        .services
+        .agent_control
+        .subscribe_progress_seq(session.conversation_id)
+        .await
+        .expect("progress seq subscription should succeed");
+
+    session
+        .send_event_raw(
+            codex_protocol::protocol::Event {
+                id: "raw-shutdown".to_string(),
+                msg: EventMsg::ShutdownComplete,
+            },
+            ProgressObservation::Observe,
+        )
+        .await;
+
+    timeout(Duration::from_secs(1), progress_seq_rx.changed())
+        .await
+        .expect("shutdown complete should advance progress seq")
+        .expect("progress receiver should remain open");
+    assert_eq!(*progress_seq_rx.borrow(), 1);
+
+    let snapshot = session
+        .services
+        .agent_control
+        .inspect_agent_progress(session.conversation_id, Duration::from_millis(100))
+        .await;
+    assert_eq!(
+        snapshot.phase,
+        codex_agent_observability::AgentProgressPhase::Shutdown
+    );
+    assert_eq!(snapshot.lifecycle_status, AgentStatus::Shutdown);
+}
+
+#[tokio::test]
+async fn observed_raw_warning_preserves_progress_seq() {
+    let (session, _turn, _manager) = manager_backed_session_and_turn().await;
+    let mut progress_seq_rx = session
+        .services
+        .agent_control
+        .subscribe_progress_seq(session.conversation_id)
+        .await
+        .expect("progress seq subscription should succeed");
+
+    session
+        .send_event_raw(
+            codex_protocol::protocol::Event {
+                id: "raw-warning".to_string(),
+                msg: EventMsg::Warning(WarningEvent {
+                    message: "heads up".to_string(),
+                }),
+            },
+            ProgressObservation::Observe,
+        )
+        .await;
+
+    assert!(
+        timeout(Duration::from_millis(50), progress_seq_rx.changed())
+            .await
+            .is_err()
+    );
+    assert_eq!(*progress_seq_rx.borrow(), 0);
+
+    let snapshot = session
+        .services
+        .agent_control
+        .inspect_agent_progress(session.conversation_id, Duration::from_millis(100))
+        .await;
+    assert_eq!(snapshot.seq, 0);
+    assert_eq!(
+        snapshot.recent_updates,
+        vec!["warning: heads up".to_string()]
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -6,6 +6,7 @@ use crate::guardian::review_approval_request;
 use crate::guardian::routes_approval_to_guardian;
 use crate::hook_runtime::run_permission_request_hooks;
 use crate::network_policy_decision::denied_network_policy_message;
+use crate::session::ProgressObservation;
 use crate::session::session::Session;
 use crate::tools::sandboxing::PermissionRequestPayload;
 use crate::tools::sandboxing::ToolError;
@@ -482,10 +483,13 @@ impl NetworkApprovalService {
                                 format!("Failed to apply network policy amendment: {err}");
                             warn!("{message}");
                             session
-                                .send_event_raw(Event {
-                                    id: turn_context.sub_id.clone(),
-                                    msg: EventMsg::Warning(WarningEvent { message }),
-                                })
+                                .send_event_raw(
+                                    Event {
+                                        id: turn_context.sub_id.clone(),
+                                        msg: EventMsg::Warning(WarningEvent { message }),
+                                    },
+                                    ProgressObservation::Observe,
+                                )
                                 .await;
                         }
                     }
@@ -512,10 +516,13 @@ impl NetworkApprovalService {
                                 format!("Failed to apply network policy amendment: {err}");
                             warn!("{message}");
                             session
-                                .send_event_raw(Event {
-                                    id: turn_context.sub_id.clone(),
-                                    msg: EventMsg::Warning(WarningEvent { message }),
-                                })
+                                .send_event_raw(
+                                    Event {
+                                        id: turn_context.sub_id.clone(),
+                                        msg: EventMsg::Warning(WarningEvent { message }),
+                                    },
+                                    ProgressObservation::Observe,
+                                )
                                 .await;
                         }
                     }


### PR DESCRIPTION
## Summary
- make session progress observation explicit with a typed `ProgressObservation` boundary
- observe primary events exactly once while treating generated legacy echoes as compatibility-only
- add manager-backed regression tests for raw observed events and single-observation primary item starts

## Details
This is PR 2 from the 0.122 observability follow-up plan.

The session boundary now owns the observation decision:
- `send_event(...)` sends the primary event with `Observe`
- generated legacy compatibility echoes are sent with `CompatibilityOnly`
- direct production `send_event_raw(...)` callsites now opt into `Observe` explicitly
- status updates still happen before progress-registry wakeups
- rollout persistence remains independent of observation

## Validation
Targeted checks that passed:
- `cargo check -p codex-core`
- `cargo test -p codex-core session_send_event_observes_primary_item_started_once_with_legacy_echoes --lib`
- `cargo test -p codex-core observed_raw_ --lib`
- `cargo test -p codex-core wait_for_agent_progress_returns_on_material_progress --lib`
- `just fix -p codex-core`
- `just fmt`

Broader check run:
- `cargo test -p codex-core`

That broader `codex-core` sweep is still not green on the current 0.122 baseline. The failures are in other integration clusters, including:
- `suite::request_permissions::*`
- `suite::shell_command::output_with_login`
- `suite::shell_serialization::*shellcommand*`
- `suite::tool_parallelism::shell_tools_run_in_parallel`
- `suite::truncation::*`
- `suite::approvals::approval_matrix_covers_all_modes`
- `suite::unified_exec::*`

This PR does not touch those areas; it is scoped to the session observation seam plus targeted observability regression tests.
