### PR TITLE
[codex] Wire semantic broker into turn prompt assembly

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1975,6 +1975,7 @@ dependencies = [
  "codex-rollout",
  "codex-sandboxing",
  "codex-secrets",
+ "codex-semantic-broker",
  "codex-shell-command",
  "codex-shell-escalation",
  "codex-state",

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -60,6 +60,7 @@ codex-response-debug-context = { workspace = true }
 codex-rollout = { workspace = true }
 codex-rmcp-client = { workspace = true }
 codex-sandboxing = { workspace = true }
+codex-semantic-broker = { workspace = true }
 codex-state = { workspace = true }
 codex-terminal-detection = { workspace = true }
 codex-thread-store = { workspace = true }

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -92,6 +92,7 @@ pub(crate) mod mentions {
 }
 mod sandbox_tags;
 pub mod sandboxing;
+mod semantic_broker_runtime;
 mod session_prefix;
 mod session_startup_prewarm;
 mod shell_detect;

--- a/codex-rs/core/src/semantic_broker_runtime.rs
+++ b/codex-rs/core/src/semantic_broker_runtime.rs
@@ -1,0 +1,77 @@
+use crate::session::turn_context::TurnContext;
+use crate::tools::ToolRouter;
+use codex_features::Feature;
+use codex_protocol::models::ResponseItem;
+use codex_semantic_broker::BrokerInput;
+use codex_semantic_broker::DeterministicAdjudicator;
+use codex_semantic_broker::PacketBudget;
+use codex_semantic_broker::adjudicate_candidates;
+use codex_semantic_broker::build_active_context_packet;
+use codex_semantic_broker::build_candidate_set;
+use codex_semantic_broker::builtin_registry;
+use codex_semantic_broker::render_active_context_packet_item;
+use tracing::warn;
+
+pub(crate) fn append_semantic_broker_prompt_overlay(
+    mut prompt_input: Vec<ResponseItem>,
+    router: &ToolRouter,
+    turn_context: &TurnContext,
+) -> Vec<ResponseItem> {
+    if !turn_context.features.enabled(Feature::SemanticBroker) {
+        return prompt_input;
+    }
+
+    let registry = match builtin_registry() {
+        Ok(registry) => registry,
+        Err(err) => {
+            warn!("semantic broker disabled for this prompt build: {err}");
+            return prompt_input;
+        }
+    };
+
+    let broker_input = BrokerInput {
+        current_turn_text: current_turn_text(&prompt_input),
+        visible_tool_names: visible_tool_names_for_prompt(router, turn_context),
+        session_source: Some(turn_context.session_source.clone()),
+        active_track: None,
+    };
+    let candidates = build_candidate_set(&broker_input, &registry);
+    let resolution = adjudicate_candidates(
+        &broker_input,
+        &candidates,
+        &DeterministicAdjudicator::default(),
+    );
+    let packet = build_active_context_packet(&broker_input, &resolution);
+    prompt_input.push(render_active_context_packet_item(
+        &packet,
+        &PacketBudget::default(),
+    ));
+    prompt_input
+}
+
+fn current_turn_text(prompt_input: &[ResponseItem]) -> Option<String> {
+    prompt_input.iter().rev().find_map(|item| match item {
+        ResponseItem::Message { role, content, .. } if role == "user" => {
+            codex_protocol::models::content_items_to_text(content)
+        }
+        _ => None,
+    })
+}
+
+fn visible_tool_names_for_prompt(router: &ToolRouter, turn_context: &TurnContext) -> Vec<String> {
+    let deferred_dynamic_tools = turn_context
+        .dynamic_tools
+        .iter()
+        .filter(|tool| tool.defer_loading)
+        .map(|tool| tool.name.as_str())
+        .collect::<std::collections::HashSet<_>>();
+
+    let mut tool_names = router
+        .model_visible_specs()
+        .into_iter()
+        .filter(|spec| !deferred_dynamic_tools.contains(spec.name()))
+        .map(|spec| spec.name().to_string())
+        .collect::<Vec<_>>();
+    tool_names.sort();
+    tool_names
+}

--- a/codex-rs/core/src/semantic_broker_runtime.rs
+++ b/codex-rs/core/src/semantic_broker_runtime.rs
@@ -1,6 +1,8 @@
+use crate::event_mapping::parse_turn_item;
 use crate::session::turn_context::TurnContext;
 use crate::tools::ToolRouter;
 use codex_features::Feature;
+use codex_protocol::items::TurnItem;
 use codex_protocol::models::ResponseItem;
 use codex_semantic_broker::BrokerInput;
 use codex_semantic_broker::DeterministicAdjudicator;
@@ -50,12 +52,31 @@ pub(crate) fn append_semantic_broker_prompt_overlay(
 }
 
 fn current_turn_text(prompt_input: &[ResponseItem]) -> Option<String> {
-    prompt_input.iter().rev().find_map(|item| match item {
-        ResponseItem::Message { role, content, .. } if role == "user" => {
-            codex_protocol::models::content_items_to_text(content)
+    for item in prompt_input.iter().rev() {
+        let ResponseItem::Message { role, .. } = item else {
+            continue;
+        };
+        if role != "user" {
+            continue;
         }
-        _ => None,
-    })
+
+        return match parse_turn_item(item) {
+            Some(TurnItem::UserMessage(user_message)) => {
+                let text = user_message.message();
+                (!text.is_empty()).then_some(text)
+            }
+            Some(TurnItem::HookPrompt(_))
+            | Some(TurnItem::AgentMessage(_))
+            | Some(TurnItem::Plan(_))
+            | Some(TurnItem::Reasoning(_))
+            | Some(TurnItem::WebSearch(_))
+            | Some(TurnItem::ImageGeneration(_))
+            | Some(TurnItem::ContextCompaction(_))
+            | None => None,
+        };
+    }
+
+    None
 }
 
 fn visible_tool_names_for_prompt(router: &ToolRouter, turn_context: &TurnContext) -> Vec<String> {

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -37,6 +37,7 @@ use crate::mentions::collect_tool_mentions_from_messages;
 use crate::parse_turn_item;
 use crate::plugins::build_plugin_injections;
 use crate::resolve_skill_dependencies_for_turn;
+use crate::semantic_broker_runtime::append_semantic_broker_prompt_overlay;
 use crate::session::PreviousTurnSettings;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
@@ -1050,6 +1051,11 @@ async fn run_sampling_request(
                 .await
                 .for_prompt(&turn_context.model_info.input_modalities)
         };
+        let prompt_input = append_semantic_broker_prompt_overlay(
+            prompt_input,
+            router.as_ref(),
+            turn_context.as_ref(),
+        );
         let prompt = build_prompt(
             prompt_input,
             router.as_ref(),

--- a/codex-rs/core/src/session/turn_tests.rs
+++ b/codex-rs/core/src/session/turn_tests.rs
@@ -1,12 +1,16 @@
 use super::tests::make_session_and_context;
 use super::turn::build_prompt;
 use super::turn::built_tools;
+use crate::contextual_user_message::USER_SHELL_COMMAND_CLOSE_TAG;
+use crate::contextual_user_message::USER_SHELL_COMMAND_OPEN_TAG;
 use crate::semantic_broker_runtime::append_semantic_broker_prompt_overlay;
 use codex_features::Feature;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
+use codex_semantic_broker::ConfidenceDecision;
 use codex_semantic_broker::is_active_context_packet_text;
 use pretty_assertions::assert_eq;
+use serde::Deserialize;
 use std::collections::HashSet;
 use tokio_util::sync::CancellationToken;
 
@@ -20,6 +24,71 @@ fn developer_overlay(text: &str) -> ResponseItem {
         end_turn: None,
         phase: None,
     }
+}
+
+fn user_message(text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: text.to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }
+}
+
+fn contextual_user_shell_message(command: &str) -> ResponseItem {
+    user_message(&format!(
+        "{USER_SHELL_COMMAND_OPEN_TAG}{command}{USER_SHELL_COMMAND_CLOSE_TAG}"
+    ))
+}
+
+fn image_only_user_message() -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputImage {
+            image_url: "data:image/png;base64,AAAA".to_string(),
+            detail: None,
+        }],
+        end_turn: None,
+        phase: None,
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct RenderedSemanticBrokerResolution {
+    decision: ConfidenceDecision,
+    selected_schema_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct RenderedSemanticBrokerWitness {
+    matched_terms: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct RenderedSemanticBrokerPacket {
+    resolution: RenderedSemanticBrokerResolution,
+    witness: RenderedSemanticBrokerWitness,
+}
+
+fn parse_broker_packet(item: &ResponseItem) -> RenderedSemanticBrokerPacket {
+    let ResponseItem::Message { content, .. } = item else {
+        panic!("expected developer message");
+    };
+    let [ContentItem::InputText { text }] = content.as_slice() else {
+        panic!("expected single input text item");
+    };
+    let prefix = "<active_context_packet schema=\"codex.semantic_broker.active_packet.v0\">";
+    let suffix = "</active_context_packet>";
+    let payload = text
+        .strip_prefix(prefix)
+        .and_then(|payload| payload.strip_suffix(suffix))
+        .expect("expected tagged packet");
+
+    serde_json::from_str(payload).expect("packet payload should deserialize")
 }
 
 #[tokio::test]
@@ -150,4 +219,94 @@ async fn semantic_broker_feature_on_appends_one_prompt_only_overlay() {
     );
     assert_eq!(history_after, history_before);
     assert!(!history_after.contains(overlay));
+}
+
+#[tokio::test]
+async fn semantic_broker_ignores_older_text_when_latest_user_message_is_contextual() {
+    let (session, mut turn_context) = make_session_and_context().await;
+    turn_context
+        .features
+        .enable(Feature::SemanticBroker)
+        .expect("enable semantic broker");
+    let cancellation_token = CancellationToken::new();
+    let history_before = session
+        .clone_history()
+        .await
+        .for_prompt(&turn_context.model_info.input_modalities);
+    let router = built_tools(
+        &session,
+        &turn_context,
+        &history_before,
+        &HashSet::new(),
+        Some(turn_context.turn_skills.outcome.as_ref()),
+        &cancellation_token,
+    )
+    .await
+    .expect("build tool router");
+
+    let mut prompt_input = history_before;
+    prompt_input.push(user_message("review this change"));
+    prompt_input.push(contextual_user_shell_message("git status"));
+
+    let prompt_input =
+        append_semantic_broker_prompt_overlay(prompt_input, router.as_ref(), &turn_context);
+    let packet = parse_broker_packet(prompt_input.last().expect("semantic broker overlay"));
+
+    assert_eq!(
+        packet,
+        RenderedSemanticBrokerPacket {
+            resolution: RenderedSemanticBrokerResolution {
+                decision: ConfidenceDecision::Unresolved,
+                selected_schema_id: None,
+            },
+            witness: RenderedSemanticBrokerWitness {
+                matched_terms: Vec::new(),
+            },
+        }
+    );
+}
+
+#[tokio::test]
+async fn semantic_broker_does_not_fall_back_past_latest_image_only_user_message() {
+    let (session, mut turn_context) = make_session_and_context().await;
+    turn_context
+        .features
+        .enable(Feature::SemanticBroker)
+        .expect("enable semantic broker");
+    let cancellation_token = CancellationToken::new();
+    let history_before = session
+        .clone_history()
+        .await
+        .for_prompt(&turn_context.model_info.input_modalities);
+    let router = built_tools(
+        &session,
+        &turn_context,
+        &history_before,
+        &HashSet::new(),
+        Some(turn_context.turn_skills.outcome.as_ref()),
+        &cancellation_token,
+    )
+    .await
+    .expect("build tool router");
+
+    let mut prompt_input = history_before;
+    prompt_input.push(user_message("review this change"));
+    prompt_input.push(image_only_user_message());
+
+    let prompt_input =
+        append_semantic_broker_prompt_overlay(prompt_input, router.as_ref(), &turn_context);
+    let packet = parse_broker_packet(prompt_input.last().expect("semantic broker overlay"));
+
+    assert_eq!(
+        packet,
+        RenderedSemanticBrokerPacket {
+            resolution: RenderedSemanticBrokerResolution {
+                decision: ConfidenceDecision::Unresolved,
+                selected_schema_id: None,
+            },
+            witness: RenderedSemanticBrokerWitness {
+                matched_terms: Vec::new(),
+            },
+        }
+    );
 }

--- a/codex-rs/core/src/session/turn_tests.rs
+++ b/codex-rs/core/src/session/turn_tests.rs
@@ -1,8 +1,11 @@
 use super::tests::make_session_and_context;
 use super::turn::build_prompt;
 use super::turn::built_tools;
+use crate::semantic_broker_runtime::append_semantic_broker_prompt_overlay;
+use codex_features::Feature;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
+use codex_semantic_broker::is_active_context_packet_text;
 use pretty_assertions::assert_eq;
 use std::collections::HashSet;
 use tokio_util::sync::CancellationToken;
@@ -58,4 +61,93 @@ async fn build_prompt_allows_prompt_only_overlay_without_persisting_history() {
     assert_eq!(prompt.input.last(), Some(&overlay));
     assert_eq!(history_after, history_before);
     assert!(!history_after.contains(&overlay));
+}
+
+#[tokio::test]
+async fn semantic_broker_feature_off_leaves_prompt_input_unchanged() {
+    let (session, turn_context) = make_session_and_context().await;
+    let cancellation_token = CancellationToken::new();
+    let history_before = session
+        .clone_history()
+        .await
+        .for_prompt(&turn_context.model_info.input_modalities);
+    let router = built_tools(
+        &session,
+        &turn_context,
+        &history_before,
+        &HashSet::new(),
+        Some(turn_context.turn_skills.outcome.as_ref()),
+        &cancellation_token,
+    )
+    .await
+    .expect("build tool router");
+
+    let prompt_input = append_semantic_broker_prompt_overlay(
+        history_before.clone(),
+        router.as_ref(),
+        &turn_context,
+    );
+
+    assert_eq!(prompt_input, history_before);
+}
+
+#[tokio::test]
+async fn semantic_broker_feature_on_appends_one_prompt_only_overlay() {
+    let (session, mut turn_context) = make_session_and_context().await;
+    turn_context
+        .features
+        .enable(Feature::SemanticBroker)
+        .expect("enable semantic broker");
+    let cancellation_token = CancellationToken::new();
+    let history_before = session
+        .clone_history()
+        .await
+        .for_prompt(&turn_context.model_info.input_modalities);
+    let router = built_tools(
+        &session,
+        &turn_context,
+        &history_before,
+        &HashSet::new(),
+        Some(turn_context.turn_skills.outcome.as_ref()),
+        &cancellation_token,
+    )
+    .await
+    .expect("build tool router");
+
+    let prompt_input = append_semantic_broker_prompt_overlay(
+        history_before.clone(),
+        router.as_ref(),
+        &turn_context,
+    );
+    let prompt = build_prompt(
+        prompt_input.clone(),
+        router.as_ref(),
+        &turn_context,
+        session.get_base_instructions().await,
+    );
+    let history_after = session
+        .clone_history()
+        .await
+        .for_prompt(&turn_context.model_info.input_modalities);
+    let overlay = prompt.input.last().expect("semantic broker overlay");
+    let ResponseItem::Message { role, content, .. } = overlay else {
+        panic!("expected developer message");
+    };
+    let [ContentItem::InputText { text }] = content.as_slice() else {
+        panic!("expected single input text item");
+    };
+
+    assert_eq!(role, "developer");
+    assert!(is_active_context_packet_text(text));
+    assert_eq!(
+        prompt_input
+            .iter()
+            .filter(|item| matches!(item, ResponseItem::Message { role, content, .. }
+                if role == "developer"
+                    && matches!(content.as_slice(), [ContentItem::InputText { text }] if is_active_context_packet_text(text))))
+            .count(),
+        1
+    );
+    assert_eq!(history_after, history_before);
+    assert!(!history_after.contains(overlay));
 }

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -174,6 +174,8 @@ pub enum Feature {
     /// Enable collaboration modes (Plan, Default).
     /// Kept for config backward compatibility; behavior is always collaboration-modes-enabled.
     CollaborationModes,
+    /// Enable prompt-only semantic broker overlays at the turn prompt seam.
+    SemanticBroker,
     /// Route MCP tool approval prompts through the MCP elicitation request path.
     ToolCallMcpElicitation,
     /// Enable personality selection in the TUI.
@@ -903,6 +905,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "collaboration_modes",
         stage: Stage::Removed,
         default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::SemanticBroker,
+        key: "semantic_broker",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
     },
     FeatureSpec {
         id: Feature::ToolCallMcpElicitation,

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -139,6 +139,12 @@ fn request_permissions_tool_is_under_development() {
 }
 
 #[test]
+fn semantic_broker_is_under_development() {
+    assert_eq!(Feature::SemanticBroker.stage(), Stage::UnderDevelopment);
+    assert_eq!(Feature::SemanticBroker.default_enabled(), false);
+}
+
+#[test]
 fn tool_suggest_is_stable_and_enabled_by_default() {
     assert_eq!(Feature::ToolSuggest.stage(), Stage::Stable);
     assert_eq!(Feature::ToolSuggest.default_enabled(), true);


### PR DESCRIPTION
## Summary
- add the `semantic_broker` feature flag and core dependency on `codex-semantic-broker`
- introduce a small runtime adapter that appends one broker-owned developer overlay after `History::for_prompt(...)`
- keep the packet prompt-only and non-durable, with focused seam tests for feature-off and feature-on behavior

## Scope
This is the planned S2 PR for the semantic broker family.

It wires the live seam, but it does **not**:
- persist the broker packet into history
- merge broker semantics into governance layers
- add protocol surface area

## Validation
- `cargo test -p codex-features`
- `cargo test -p codex-core semantic_broker_feature_ --lib`
- `cargo test -p codex-core build_prompt_allows_prompt_only_overlay_without_persisting_history --lib`
- `cargo check -p codex-core`
- isolated Bazel lock verification:
  - `bazel ... mod deps --lockfile_mode=update`
  - `bazel ... mod deps --lockfile_mode=error`
- `just fix -p codex-features`
- `just fix -p codex-core`
- `just fmt`

## Notes
- `Cargo.lock` changed only to record the new `codex-core -> codex-semantic-broker` dependency edge
- `MODULE.bazel.lock` did not need an update
- Bazel verification used isolated cache roots because the machine's default `~/.cache` path is locally broken
