### PR TITLE
SB-H1: pass semantic broker current-turn text explicitly

### DIFF
--- a/codex-rs/core/src/semantic_broker_runtime.rs
+++ b/codex-rs/core/src/semantic_broker_runtime.rs
@@ -16,6 +16,7 @@ use tracing::warn;
 
 pub(crate) fn append_semantic_broker_prompt_overlay(
     mut prompt_input: Vec<ResponseItem>,
+    current_turn_text: Option<String>,
     router: &ToolRouter,
     turn_context: &TurnContext,
 ) -> Vec<ResponseItem> {
@@ -32,7 +33,8 @@ pub(crate) fn append_semantic_broker_prompt_overlay(
     };
 
     let broker_input = BrokerInput {
-        current_turn_text: current_turn_text(&prompt_input),
+        current_turn_text: current_turn_text
+            .or_else(|| current_turn_text_from_prompt_input(&prompt_input)),
         visible_tool_names: visible_tool_names_for_prompt(router, turn_context),
         session_source: Some(turn_context.session_source.clone()),
         active_track: None,
@@ -51,7 +53,7 @@ pub(crate) fn append_semantic_broker_prompt_overlay(
     prompt_input
 }
 
-fn current_turn_text(prompt_input: &[ResponseItem]) -> Option<String> {
+fn current_turn_text_from_prompt_input(prompt_input: &[ResponseItem]) -> Option<String> {
     for item in prompt_input.iter().rev() {
         let ResponseItem::Message { role, .. } = item else {
             continue;

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -302,17 +302,15 @@ pub(crate) async fn run_turn(
     if run_pending_session_start_hooks(&sess, &turn_context).await {
         return None;
     }
+    let initial_user_message_text = UserMessageItem::new(&input).message();
     let additional_contexts = if input.is_empty() {
         Vec::new()
     } else {
         let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input.clone());
         let response_item: ResponseItem = initial_input_for_turn.clone().into();
-        let user_prompt_submit_outcome = run_user_prompt_submit_hooks(
-            &sess,
-            &turn_context,
-            UserMessageItem::new(&input).message(),
-        )
-        .await;
+        let user_prompt_submit_outcome =
+            run_user_prompt_submit_hooks(&sess, &turn_context, initial_user_message_text.clone())
+                .await;
         if user_prompt_submit_outcome.should_stop {
             record_additional_contexts(
                 &sess,
@@ -408,10 +406,8 @@ pub(crate) async fn run_turn(
     // 1. At the start of a turn, so the fresh user prompt in `input` gets sampled first.
     // 2. After auto-compact, when model/tool continuation needs to resume before any steer.
     let mut can_drain_pending_input = input.is_empty();
-    let mut broker_current_turn_text = {
-        let text = UserMessageItem::new(&input).message();
-        (!text.trim().is_empty()).then_some(text)
-    };
+    let mut broker_current_turn_text =
+        (!initial_user_message_text.trim().is_empty()).then_some(initial_user_message_text);
 
     loop {
         if run_pending_session_start_hooks(&sess, &turn_context).await {

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -19,6 +19,7 @@ use crate::context::ContextualUserFragment;
 use crate::context_maintenance_runtime::CompactInvocationTiming;
 use crate::feedback_tags;
 use crate::hook_runtime::PendingInputHookDisposition;
+use crate::hook_runtime::PendingInputRecord;
 use crate::hook_runtime::emit_hook_completed_events;
 use crate::hook_runtime::inspect_pending_input;
 use crate::hook_runtime::record_additional_contexts;
@@ -407,6 +408,10 @@ pub(crate) async fn run_turn(
     // 1. At the start of a turn, so the fresh user prompt in `input` gets sampled first.
     // 2. After auto-compact, when model/tool continuation needs to resume before any steer.
     let mut can_drain_pending_input = input.is_empty();
+    let mut broker_current_turn_text = {
+        let text = UserMessageItem::new(&input).message();
+        (!text.trim().is_empty()).then_some(text)
+    };
 
     loop {
         if run_pending_session_start_hooks(&sess, &turn_context).await {
@@ -451,6 +456,10 @@ pub(crate) async fn run_turn(
 
         let has_accepted_pending_input = !accepted_pending_input.is_empty();
         for pending_input in accepted_pending_input {
+            if let PendingInputRecord::UserMessage { content, .. } = &pending_input {
+                let text = UserMessageItem::new(content.as_slice()).message();
+                broker_current_turn_text = (!text.trim().is_empty()).then_some(text);
+            }
             record_pending_input(&sess, &turn_context, pending_input).await;
         }
         record_additional_contexts(&sess, &turn_context, blocked_pending_input_contexts).await;
@@ -485,6 +494,7 @@ pub(crate) async fn run_turn(
             &mut client_session,
             turn_metadata_header.as_deref(),
             sampling_request_input,
+            broker_current_turn_text.clone(),
             &explicitly_enabled_connectors,
             skills_outcome,
             &mut server_model_warning_emitted_for_turn,
@@ -1049,6 +1059,7 @@ async fn run_sampling_request(
     client_session: &mut ModelClientSession,
     turn_metadata_header: Option<&str>,
     input: Vec<ResponseItem>,
+    current_turn_text: Option<String>,
     explicitly_enabled_connectors: &HashSet<String>,
     skills_outcome: Option<&SkillLoadOutcome>,
     server_model_warning_emitted_for_turn: &mut bool,
@@ -1094,6 +1105,7 @@ async fn run_sampling_request(
         };
         let prompt_input = append_semantic_broker_prompt_overlay(
             prompt_input,
+            current_turn_text.clone(),
             router.as_ref(),
             turn_context.as_ref(),
         );

--- a/codex-rs/core/src/session/turn_tests.rs
+++ b/codex-rs/core/src/session/turn_tests.rs
@@ -155,6 +155,7 @@ async fn semantic_broker_feature_off_leaves_prompt_input_unchanged() {
 
     let prompt_input = append_semantic_broker_prompt_overlay(
         history_before.clone(),
+        None,
         router.as_ref(),
         &turn_context,
     );
@@ -187,6 +188,7 @@ async fn semantic_broker_feature_on_appends_one_prompt_only_overlay() {
 
     let prompt_input = append_semantic_broker_prompt_overlay(
         history_before.clone(),
+        None,
         router.as_ref(),
         &turn_context,
     );
@@ -224,7 +226,7 @@ async fn semantic_broker_feature_on_appends_one_prompt_only_overlay() {
 }
 
 #[tokio::test]
-async fn semantic_broker_ignores_older_text_when_latest_user_message_is_contextual() {
+async fn semantic_broker_uses_explicit_current_turn_text_when_latest_user_message_is_contextual() {
     let (session, mut turn_context) = make_session_and_context().await;
     turn_context
         .features
@@ -250,19 +252,23 @@ async fn semantic_broker_ignores_older_text_when_latest_user_message_is_contextu
     prompt_input.push(user_message("review this change"));
     prompt_input.push(contextual_user_shell_message("git status"));
 
-    let prompt_input =
-        append_semantic_broker_prompt_overlay(prompt_input, router.as_ref(), &turn_context);
+    let prompt_input = append_semantic_broker_prompt_overlay(
+        prompt_input,
+        Some("review this change".to_string()),
+        router.as_ref(),
+        &turn_context,
+    );
     let packet = parse_broker_packet(prompt_input.last().expect("semantic broker overlay"));
 
     assert_eq!(
         packet,
         RenderedSemanticBrokerPacket {
             resolution: RenderedSemanticBrokerResolution {
-                decision: ConfidenceDecision::Unresolved,
-                selected_schema_id: None,
+                decision: ConfidenceDecision::Resolved,
+                selected_schema_id: Some("workflow.review.code".to_string()),
             },
             witness: RenderedSemanticBrokerWitness {
-                matched_terms: Vec::new(),
+                matched_terms: vec!["review this".to_string()],
             },
         }
     );
@@ -296,7 +302,7 @@ async fn semantic_broker_does_not_fall_back_past_latest_image_only_user_message(
     prompt_input.push(image_only_user_message());
 
     let prompt_input =
-        append_semantic_broker_prompt_overlay(prompt_input, router.as_ref(), &turn_context);
+        append_semantic_broker_prompt_overlay(prompt_input, None, router.as_ref(), &turn_context);
     let packet = parse_broker_packet(prompt_input.last().expect("semantic broker overlay"));
 
     assert_eq!(

--- a/docs/fork/semantic-broker-v0-hardening-implementation-spec.md
+++ b/docs/fork/semantic-broker-v0-hardening-implementation-spec.md
@@ -1,0 +1,224 @@
+# Semantic Broker v0 Hardening Implementation Spec (Post-0.123)
+
+This spec defines the first hardening slice after the `0.123` ingest for the
+new semantic-broker module and its adjacent observability seam.
+
+Primary references:
+
+- [semantic-broker-implementation-spec.md](/home/rose/work/codex/fork/docs/fork/semantic-broker-implementation-spec.md)
+- [agent-observability-122-followup-implementation-spec.md](/home/rose/work/codex/fork/docs/fork/agent-observability-122-followup-implementation-spec.md)
+- [release-alignment-log.md](/home/rose/work/codex/fork/docs/fork/release-alignment-log.md)
+
+## Judgment
+
+The architecture is correct and should stay as-is:
+
+- `codex-semantic-broker` owns registry/candidate/adjudication/packet law.
+- `core/src/semantic_broker_runtime.rs` stays a thin runtime adapter.
+- `Feature::SemanticBroker` remains default-off.
+
+There is one functional v0 bug to fix before calling broker ingress stable:
+
+- current turn text is inferred from prompt tail scanning and can be lost when
+  contextual user fragments (especially skill fragments) are appended after the
+  actual user prompt in the same turn.
+
+Secondary hardening in this family:
+
+- make broker packet rendering robust against tag-breaking payload content.
+- make observability reducer no-op coverage explicit for key wildcarded events.
+
+## Scope
+
+In scope:
+
+1. Fix semantic broker current-turn text ingress (P0).
+2. Harden active packet rendering envelope (P1).
+3. Add explicit observability no-op classification for selected wildcarded
+   variants (P1).
+4. Reduce broker packet contract duplication in core tests (P2).
+
+Out of scope:
+
+- enabling `semantic_broker` by default.
+- introducing durable broker artifacts in conversation history.
+- protocol-level packet variants.
+- broad governance-layer refactor in `session/mod.rs`.
+- changing thread-memory governance semantics in this slice.
+
+## Required Invariants
+
+1. Broker remains prompt-only.
+2. Broker remains semantic owner of packet tag/schema/render contract.
+3. Core remains adapter-only; no second broker doctrine in `core`.
+4. Observability reducer remains semantic owner of progress classification; no
+   re-ownership in `core`.
+5. Existing context-maintenance crate boundaries remain unchanged.
+
+## Work Packages
+
+### H1 (P0): Explicit current-turn text ingress for broker
+
+Problem:
+
+- `append_semantic_broker_prompt_overlay(...)` currently builds `BrokerInput`
+  with `current_turn_text(&prompt_input)` from reverse prompt scanning.
+- In the same turn, `run_turn(...)` records the user prompt and then appends
+  contextual user fragments (`skill_items`, `plugin_items`) to history.
+- Reverse scan hits the latest contextual user message first and can return
+  `None`, losing the real same-turn user prompt.
+
+Target design:
+
+- `run_turn` / `run_sampling_request` passes explicit current-turn text into
+  semantic broker runtime.
+- Runtime adapter prefers this explicit text and does not rely on prompt-tail
+  inference for the main turn path.
+- Prompt scanning may remain only as fallback for non-standard call paths.
+
+Required file changes:
+
+- [turn.rs](/home/rose/work/codex/fork/codex-rs/core/src/session/turn.rs)
+- [semantic_broker_runtime.rs](/home/rose/work/codex/fork/codex-rs/core/src/semantic_broker_runtime.rs)
+- [turn_tests.rs](/home/rose/work/codex/fork/codex-rs/core/src/session/turn_tests.rs)
+
+Required tests:
+
+1. Keep the guard that broker does not fall back past a latest image-only user
+   message.
+2. Replace/adjust the contextual-user test doctrine so same-turn contextual
+   fragments after a real user prompt do not erase current-turn text.
+3. Keep the prompt-only overlay invariants (exactly one overlay in prompt input,
+   no durable history mutation).
+
+Acceptance criteria:
+
+- A turn with user text plus trailing skill/contextual fragment produces broker
+  resolution based on that same-turn user text (not unresolved by default).
+
+### H2 (P1): Packet envelope hardening in semantic broker render path
+
+Problem:
+
+- broker packet JSON is embedded directly between XML-like tags:
+  `<active_context_packet ...>{json}</active_context_packet>`.
+- payload content containing tag-breaking substrings can corrupt the envelope.
+
+Target design:
+
+- escape `<`, `>`, `&` in payload JSON before embedding (for example via unicode
+  escapes) while preserving valid JSON round-trip semantics.
+
+Required file changes:
+
+- [render.rs](/home/rose/work/codex/fork/codex-rs/semantic-broker/src/render.rs)
+- broker render tests in the same module.
+
+Required tests:
+
+1. A malicious tool binding containing `</active_context_packet>` does not break
+   packet envelope recognition.
+2. Rendered payload still deserializes to expected packet contract.
+
+Acceptance criteria:
+
+- `is_active_context_packet_text(...)` remains true for escaped payloads.
+- Packet contract parsing tests continue to pass.
+
+### H3 (P1): Explicit no-op classification for wildcarded progress events
+
+Problem:
+
+- `codex-agent-observability` reducer still has a broad `_ => {}` arm.
+- Key progress-adjacent events are currently implicit via wildcard.
+
+Target design:
+
+- explicitly classify selected variants as named no-ops (no seq bump, no phase
+  mutation) in reducer match arms.
+- keep current behavior unless explicitly intended to change.
+
+Initial explicit no-op set for this slice:
+
+- `AgentReasoningRawContent`
+- `AgentReasoningSectionBreak`
+- `ViewImageToolCall`
+- `HookStarted`
+- `HookCompleted`
+- `CollabAgentSpawnBegin` / `CollabAgentSpawnEnd`
+- `CollabAgentInteractionBegin` / `CollabAgentInteractionEnd`
+- `CollabWaitingBegin` / `CollabWaitingEnd`
+- `CollabCloseBegin` / `CollabCloseEnd`
+- `CollabResumeBegin` / `CollabResumeEnd`
+
+Required file changes:
+
+- [progress.rs](/home/rose/work/codex/fork/codex-rs/agent-observability/src/progress.rs)
+
+Required tests:
+
+1. Add at least one representative no-op test proving seq/phase unchanged.
+2. Keep existing explicit no-op tests (`PlanDelta`, `ReasoningRawContentDelta`)
+   passing.
+
+Acceptance criteria:
+
+- reducer behavior is unchanged for these variants but no longer hidden behind
+  wildcard.
+
+### H4 (P2): Remove core packet-contract literal duplication
+
+Problem:
+
+- core broker tests hardcode packet tag/schema literals.
+
+Target design:
+
+- core tests assert behavior through broker-owned helpers or central constants
+  rather than re-declaring packet envelope literals.
+
+Required file changes:
+
+- [turn_tests.rs](/home/rose/work/codex/fork/codex-rs/core/src/session/turn_tests.rs)
+
+Acceptance criteria:
+
+- no runtime behavior change.
+- less duplicate packet-contract doctrine outside broker crate.
+
+## PR Sequence
+
+Recommended sequencing:
+
+1. `SB-H1` (P0): explicit current-turn ingress + test doctrine adjustment.
+2. `SB-H2` (P1) + `SB-H4` (P2): packet escaping + test contract cleanup.
+3. `AO-H1` (P1): explicit observability no-op classification.
+
+Rationale:
+
+- ship functional broker ingress fix first.
+- keep packet/render hardening and observability hardening reviewable in small,
+  independent PRs.
+
+## Validation Plan
+
+Run after each PR as relevant:
+
+```bash
+cd codex-rs
+just fmt
+cargo test -p codex-semantic-broker
+cargo test -p codex-agent-observability
+cargo test -p codex-core semantic_broker_ --lib
+cargo test -p codex-core tools::handlers::agent_progress::tests --lib
+```
+
+If `codex-core` targeted filters miss touched tests, run explicit test names in
+`core/src/session/turn_tests.rs` and `agent-observability/src/progress.rs`.
+
+## Deferred Follow-ups (Not In This Slice)
+
+1. Decide semantic meaning of `ThreadMemoryGovernance::Disabled`
+   (naming or behavior alignment).
+2. Reduce governance-layer custom contact in `session/mod.rs` using the 0.123
+   context fragment substrate, without moving broker law into `core`.


### PR DESCRIPTION
## Summary
- add a hardening implementation spec for the post-0.123 broker/observability slice
- thread explicit current-turn user text from `run_turn` into semantic broker runtime
- keep prompt-tail scanning only as fallback in `append_semantic_broker_prompt_overlay`
- update broker turn tests so contextual user fragments after the current prompt do not erase broker resolution

## Validation
- `cd codex-rs && just fmt`
- `cd codex-rs && cargo test -p codex-core semantic_broker_`
- `cd codex-rs && cargo test -p codex-core` *(fails in this environment with broad pre-existing harness issues such as missing `codex`/`test_stdio_server` test binaries; SB-H1 targeted tests pass)*
