### PR TITLE
[codex] Cover 0.125 fork alignment seams

### DIFF
--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -60,14 +60,19 @@ use codex_protocol::protocol::TurnCompleteEvent;
 use codex_protocol::protocol::TurnStartedEvent;
 use codex_protocol::protocol::WarningEvent;
 use codex_protocol::user_input::UserInput;
+use codex_rollout_trace::RawTraceEventPayload;
+use codex_rollout_trace::ThreadStartedTraceMetadata;
 use core_test_support::TempDirExt;
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use tempfile::TempDir;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
@@ -105,6 +110,17 @@ fn thread_manager() -> ThreadManager {
         CodexAuth::from_api_key("dummy"),
         built_in_model_providers(/* openai_base_url */ /*openai_base_url*/ None)["openai"].clone(),
     )
+}
+
+fn single_trace_bundle_dir(root: &Path) -> PathBuf {
+    let mut entries = fs::read_dir(root)
+        .expect("trace root should be readable")
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<Vec<_>, _>>()
+        .expect("trace bundle entries should be readable");
+    entries.sort();
+    assert_eq!(entries.len(), 1);
+    entries.remove(0)
 }
 
 async fn manager_backed_session_and_turn() -> (
@@ -2002,6 +2018,87 @@ async fn observed_raw_warning_preserves_progress_seq() {
         snapshot.recent_updates,
         vec!["warning: heads up".to_string()]
     );
+}
+
+#[tokio::test]
+async fn compatibility_only_protocol_events_are_traced_without_progress_observation() {
+    let (mut session, turn) = make_session_and_context().await;
+    let manager = thread_manager();
+    let root = manager
+        .start_thread((*turn.config).clone())
+        .await
+        .expect("root thread should start");
+    session.services.agent_control = manager.agent_control();
+    session.conversation_id = root.thread_id;
+
+    let trace_root = TempDir::new().expect("trace root tempdir");
+    session.services.rollout_thread_trace =
+        codex_rollout_trace::ThreadTraceContext::start_root_in_root_for_test(
+            trace_root.path(),
+            ThreadStartedTraceMetadata {
+                thread_id: session.conversation_id.to_string(),
+                agent_path: "/root".to_string(),
+                task_name: None,
+                nickname: None,
+                agent_role: None,
+                session_source: SessionSource::Exec,
+                cwd: PathBuf::from("/workspace"),
+                rollout_path: None,
+                model: "gpt-test".to_string(),
+                provider_name: "test-provider".to_string(),
+                approval_policy: "never".to_string(),
+                sandbox_policy: "danger-full-access".to_string(),
+            },
+        )
+        .expect("trace context should start");
+
+    let session = Arc::new(session);
+    let mut progress_seq_rx = session
+        .services
+        .agent_control
+        .subscribe_progress_seq(session.conversation_id)
+        .await
+        .expect("progress seq subscription should succeed");
+
+    session
+        .send_event_raw(
+            codex_protocol::protocol::Event {
+                id: "compat-shutdown".to_string(),
+                msg: EventMsg::ShutdownComplete,
+            },
+            ProgressObservation::CompatibilityOnly,
+        )
+        .await;
+
+    assert!(
+        timeout(Duration::from_millis(50), progress_seq_rx.changed())
+            .await
+            .is_err()
+    );
+    assert_eq!(*progress_seq_rx.borrow(), 0);
+
+    let snapshot = session
+        .services
+        .agent_control
+        .inspect_agent_progress(session.conversation_id, Duration::from_millis(100))
+        .await;
+    assert_eq!(snapshot.seq, 0);
+
+    let event_log =
+        fs::read_to_string(single_trace_bundle_dir(trace_root.path()).join("trace.jsonl"))
+            .expect("trace event log should be readable");
+    let protocol_event_seen = event_log.lines().any(|line| {
+        let event: codex_rollout_trace::RawTraceEvent =
+            serde_json::from_str(line).expect("raw trace event");
+        matches!(
+            event.payload,
+            RawTraceEventPayload::ProtocolEventObserved {
+                event_type,
+                ..
+            } if event_type == "shutdown_complete"
+        )
+    });
+    assert!(protocol_event_seen);
 }
 
 #[tokio::test]

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -1266,6 +1266,13 @@ fn default_continuation_bridge_output() -> Value {
     })
 }
 
+fn default_thread_memory_output(marker: &str) -> Value {
+    serde_json::json!({
+        "schema": "odeu_thread_memory_v1",
+        "marker": marker,
+    })
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ContinuationBridgeRequestMatcher;
 
@@ -1293,6 +1300,31 @@ impl Match for ContinuationBridgeRequestMatcher {
                     "continuation_bridge_baton_v1" | "continuation_bridge_v2"
                 )
             })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ThreadMemoryRequestMatcher;
+
+impl Match for ThreadMemoryRequestMatcher {
+    fn matches(&self, request: &wiremock::Request) -> bool {
+        if request.url.path() != "/v1/responses" {
+            return false;
+        }
+        let body = decode_body_bytes(
+            &request.body,
+            request
+                .headers
+                .get("content-encoding")
+                .and_then(|value| value.to_str().ok()),
+        );
+        let Ok(body_json): Result<Value, _> = serde_json::from_slice(&body) else {
+            return false;
+        };
+        body_json
+            .pointer("/text/format/schema/properties/schema/enum/0")
+            .and_then(Value::as_str)
+            == Some("odeu_thread_memory_v1")
     }
 }
 
@@ -1326,6 +1358,34 @@ pub async fn mount_continuation_bridge_responder(
     let (mock, response_mock) = base_mock();
     mock.and(ContinuationBridgeRequestMatcher)
         .respond_with(sse_response(bridge_response))
+        .up_to_n_times(128)
+        .mount(server)
+        .await;
+
+    response_mock
+}
+
+pub async fn mount_default_thread_memory_responder_with_marker(
+    server: &MockServer,
+    marker: &str,
+) -> ResponseMock {
+    let memory_body = serde_json::to_string(&default_thread_memory_output(marker))
+        .expect("serialize thread memory output");
+    mount_thread_memory_responder(server, &memory_body).await
+}
+
+pub async fn mount_thread_memory_responder(
+    server: &MockServer,
+    thread_memory_body: &str,
+) -> ResponseMock {
+    let thread_memory_response = sse(vec![
+        ev_assistant_message("thread-memory-message", thread_memory_body),
+        ev_completed("thread-memory-response"),
+    ]);
+
+    let (mock, response_mock) = base_mock();
+    mock.and(ThreadMemoryRequestMatcher)
+        .respond_with(sse_response(thread_memory_response))
         .up_to_n_times(128)
         .mount(server)
         .await;

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use codex_core::compact::SUMMARY_PREFIX;
+use codex_core::config::GovernancePathVariant;
 use codex_login::CodexAuth;
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::ContentItem;
@@ -92,6 +93,14 @@ fn is_continuation_bridge_request(request: &responses::ResponsesRequest) -> bool
                 "continuation_bridge_baton_v1" | "continuation_bridge_v2"
             )
         })
+}
+
+fn is_thread_memory_request(request: &responses::ResponsesRequest) -> bool {
+    request
+        .body_json()
+        .pointer("/text/format/schema/properties/schema/enum/0")
+        .and_then(serde_json::Value::as_str)
+        == Some("odeu_thread_memory_v1")
 }
 
 fn compacted_summary_only_output(summary: &str) -> Vec<ResponseItem> {
@@ -405,6 +414,7 @@ async fn remote_compact_does_not_issue_bridge_request_when_override_is_configure
 
     test.codex
         .submit(Op::UserInput {
+            environments: None,
             items: vec![UserInput::Text {
                 text: "start remote compact flow".into(),
                 text_elements: Vec::new(),
@@ -432,6 +442,207 @@ async fn remote_compact_does_not_issue_bridge_request_when_override_is_configure
     assert_eq!(
         compact_request.body_json()["model"].as_str(),
         Some(test.session_configured.model.as_str())
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_compact_with_strict_governance_reinserts_thread_memory() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = wiremock::MockServer::start().await;
+    let bridge_mock = responses::mount_default_continuation_bridge_responder(&server).await;
+    let thread_memory_mock = responses::mount_default_thread_memory_responder_with_marker(
+        &server,
+        "STRICT_REMOTE_MEMORY",
+    )
+    .await;
+
+    let mut builder = test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+    builder = builder.with_config(|config| {
+        config.governance_path_variant = Some(GovernancePathVariant::StrictV1Shadow);
+    });
+    let test = builder.build(&server).await?;
+
+    let responses_mock = responses::mount_sse_sequence(
+        &server,
+        vec![
+            responses::sse(vec![
+                responses::ev_assistant_message("m1", "STRICT_BASELINE_REPLY"),
+                responses::ev_completed("resp-1"),
+            ]),
+            responses::sse(vec![
+                responses::ev_assistant_message("m2", "AFTER_STRICT_COMPACT_REPLY"),
+                responses::ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let compact_mock = responses::mount_compact_json_once(
+        &server,
+        serde_json::json!({
+            "output": compacted_summary_only_output("STRICT_REMOTE_COMPACTED_SUMMARY")
+        }),
+    )
+    .await;
+
+    test.codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![UserInput::Text {
+                text: "start strict remote compact flow".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+        })
+        .await?;
+    wait_for_event(&test.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    test.codex.submit(Op::Compact).await?;
+    wait_for_event(&test.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    test.codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![UserInput::Text {
+                text: "after strict compact".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+        })
+        .await?;
+    wait_for_event(&test.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let bridge_requests = bridge_mock
+        .requests()
+        .into_iter()
+        .filter(is_continuation_bridge_request)
+        .collect::<Vec<_>>();
+    assert!(
+        bridge_requests.is_empty(),
+        "turn-boundary remote compact should not issue a continuation bridge request"
+    );
+    let thread_memory_requests = thread_memory_mock
+        .requests()
+        .into_iter()
+        .filter(is_thread_memory_request)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        thread_memory_requests.len(),
+        1,
+        "strict turn-boundary remote compact should generate one thread-memory request"
+    );
+    let thread_memory_request = &thread_memory_requests[0];
+    let thread_memory_body = thread_memory_request.body_json().to_string();
+    assert!(
+        thread_memory_body.contains("start strict remote compact flow"),
+        "thread-memory request should include source user history"
+    );
+    assert!(
+        thread_memory_body.contains("STRICT_BASELINE_REPLY"),
+        "thread-memory request should include source assistant history"
+    );
+    assert_eq!(compact_mock.requests().len(), 1);
+
+    let requests = responses_mock.requests();
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected baseline and follow-up requests"
+    );
+    let follow_up_body = requests[1].body_json().to_string();
+    assert!(
+        follow_up_body.contains("<thread_memory"),
+        "follow-up request should include generated thread memory"
+    );
+    assert!(
+        follow_up_body.contains("STRICT_REMOTE_MEMORY"),
+        "follow-up request should include generated thread-memory payload"
+    );
+    assert!(
+        follow_up_body.contains("STRICT_REMOTE_COMPACTED_SUMMARY"),
+        "follow-up request should include remote compacted summary"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn strict_remote_compact_thread_memory_failure_skips_compact_endpoint() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = wiremock::MockServer::start().await;
+    let thread_memory_mock = responses::mount_thread_memory_responder(&server, "not-json").await;
+
+    let mut builder = test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+    builder = builder.with_config(|config| {
+        config.governance_path_variant = Some(GovernancePathVariant::StrictV1Shadow);
+    });
+    let test = builder.build(&server).await?;
+
+    responses::mount_sse_once(
+        &server,
+        responses::sse(vec![
+            responses::ev_assistant_message("m1", "STRICT_BASELINE_REPLY"),
+            responses::ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+    let compact_mock = responses::mount_compact_json_once(
+        &server,
+        serde_json::json!({
+            "output": compacted_summary_only_output("SHOULD_NOT_COMPACT")
+        }),
+    )
+    .await;
+
+    test.codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![UserInput::Text {
+                text: "start strict remote compact failure flow".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+        })
+        .await?;
+    wait_for_event(&test.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    test.codex.submit(Op::Compact).await?;
+
+    let error_message = wait_for_event_match(&test.codex, |event| match event {
+        EventMsg::Error(err) => Some(err.message.clone()),
+        _ => None,
+    })
+    .await;
+    assert!(
+        error_message.contains("Error running remote compact task"),
+        "expected remote compact task error prefix, got {error_message}"
+    );
+    assert!(
+        error_message.contains("failed generating required thread memory before remote compaction"),
+        "expected required thread-memory failure details, got {error_message}"
+    );
+    wait_for_event(&test.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let thread_memory_requests = thread_memory_mock
+        .requests()
+        .into_iter()
+        .filter(is_thread_memory_request)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        thread_memory_requests.len(),
+        1,
+        "strict remote compact should attempt thread-memory generation"
+    );
+    assert!(
+        compact_mock.requests().is_empty(),
+        "remote compact endpoint should not be called after required thread-memory failure"
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/model_visible_layout.rs
+++ b/codex-rs/core/tests/suite/model_visible_layout.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use codex_config::types::Personality;
+use codex_core::config::GovernancePathVariant;
 use codex_features::Feature;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
@@ -25,6 +26,8 @@ use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
 use serde_json::json;
 
 const PRETURN_CONTEXT_DIFF_CWD: &str = "PRETURN_CONTEXT_DIFF_CWD";
@@ -53,6 +56,88 @@ fn user_instructions_wrapper_count(request: &ResponsesRequest) -> usize {
         .count()
 }
 
+fn governance_prompt_layer_sections(request: &ResponsesRequest) -> Vec<String> {
+    request
+        .message_input_texts("developer")
+        .into_iter()
+        .filter(|text| text.starts_with("<governance_prompt_layers"))
+        .collect()
+}
+
+fn only_governance_prompt_layer_payload(request: &ResponsesRequest) -> Value {
+    let payloads = governance_prompt_layer_payloads(request);
+    assert_eq!(
+        payloads.len(),
+        1,
+        "expected exactly one developer-side governance prompt-layer section"
+    );
+    payloads.into_iter().next().expect("one payload")
+}
+
+fn governance_prompt_layer_payloads(request: &ResponsesRequest) -> Vec<Value> {
+    governance_prompt_layer_sections(request)
+        .iter()
+        .map(|section| governance_prompt_layer_payload(section))
+        .collect()
+}
+
+fn governance_prompt_layer_payload_for_phase(request: &ResponsesRequest, phase: &str) -> Value {
+    let payloads = governance_prompt_layer_payloads(request)
+        .into_iter()
+        .filter(|payload| payload["phase"] == json!(phase))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        payloads.len(),
+        1,
+        "expected exactly one developer-side governance prompt-layer section for phase {phase}"
+    );
+    payloads.into_iter().next().expect("one payload")
+}
+
+fn governance_prompt_layer_payload(section: &str) -> Value {
+    let json_start = section
+        .find("\n\n{")
+        .expect("governance prompt-layer section should contain a JSON payload")
+        + 2;
+    let json_end = section
+        .rfind("\n</governance_prompt_layers>")
+        .expect("governance prompt-layer section should have a closing tag");
+    serde_json::from_str(&section[json_start..json_end])
+        .expect("governance prompt-layer JSON should parse")
+}
+
+fn assert_complete_strict_prompt_layer_payload(payload: &Value, expected_phase: &str) {
+    assert_eq!(payload["schema"], json!("strict_v1_prompt_layers@1"));
+    assert_eq!(payload["path_variant"], json!("strict_v1_shadow"));
+    assert_eq!(payload["phase"], json!(expected_phase));
+    assert_eq!(
+        payload["source_presence"],
+        json!({
+            "constitutional": true,
+            "role": true,
+            "task": true,
+            "runtime": true,
+        })
+    );
+    assert_eq!(payload["compile_error"], Value::Null);
+    assert_eq!(
+        payload["active_layers"]["constitutional"]["packet_id"],
+        json!("constitution:session")
+    );
+    assert_eq!(
+        payload["active_layers"]["role"]["packet_id"],
+        json!("role:session")
+    );
+    assert_eq!(
+        payload["active_layers"]["task"]["packet_id"],
+        json!("task:turn")
+    );
+    assert_eq!(
+        payload["active_layers"]["runtime"]["packet_id"],
+        json!("runtime:turn")
+    );
+}
+
 fn format_environment_context_subagents_snapshot(subagents: &[&str]) -> String {
     let subagents_block = if subagents.is_empty() {
         String::new()
@@ -75,6 +160,193 @@ fn format_environment_context_subagents_snapshot(subagents: &[&str]) -> String {
         }],
     })];
     context_snapshot::format_response_items_snapshot(items.as_slice(), &context_snapshot_options())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn strict_governance_prompt_layers_are_visible_in_initial_request() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let responses = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_assistant_message("msg-1", "turn complete"),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    let mut builder = test_codex()
+        .with_model("gpt-5.3-codex")
+        .with_config(|config| {
+            config.governance_path_variant = Some(GovernancePathVariant::StrictV1Shadow);
+            config.developer_instructions = Some("role layer marker".to_string());
+            config.user_instructions = Some("task layer marker".to_string());
+        });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_policy(
+        "initial strict governance turn",
+        SandboxPolicy::new_read_only_policy(),
+    )
+    .await?;
+
+    let request = responses.single_request();
+    let developer_texts = request.message_input_texts("developer");
+    assert!(
+        developer_texts
+            .first()
+            .is_some_and(|text| text.starts_with("<governance_prompt_layers")),
+        "initial governance prompt-layer section should lead the developer message"
+    );
+    assert!(
+        request
+            .message_input_texts("user")
+            .iter()
+            .all(|text| !text.contains("<governance_prompt_layers")),
+        "governance prompt-layer section must stay developer-side"
+    );
+    let payload = only_governance_prompt_layer_payload(&request);
+    assert_complete_strict_prompt_layer_payload(&payload, "initial_context");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disabled_governance_omits_prompt_layers_from_initial_request() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let responses = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_assistant_message("msg-1", "turn complete"),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    let mut builder = test_codex()
+        .with_model("gpt-5.3-codex")
+        .with_config(|config| {
+            config.governance_path_variant = Some(GovernancePathVariant::Off);
+            config.developer_instructions = Some("role layer marker".to_string());
+            config.user_instructions = Some("task layer marker".to_string());
+        });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_policy(
+        "initial governance-off turn",
+        SandboxPolicy::new_read_only_policy(),
+    )
+    .await?;
+
+    let request = responses.single_request();
+    assert_eq!(
+        governance_prompt_layer_sections(&request),
+        Vec::<String>::new(),
+        "governance-off request should not include prompt-layer metadata"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn strict_governance_prompt_layers_are_visible_in_settings_update_request() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_assistant_message("msg-1", "turn one complete"),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-2", "turn two complete"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let mut builder = test_codex()
+        .with_model("gpt-5.3-codex")
+        .with_config(|config| {
+            config.governance_path_variant = Some(GovernancePathVariant::StrictV1Shadow);
+            config.developer_instructions = Some("role layer marker".to_string());
+            config.user_instructions = Some("task layer marker".to_string());
+        });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_policy(
+        "first strict governance turn",
+        SandboxPolicy::new_read_only_policy(),
+    )
+    .await?;
+
+    let settings_update_cwd = test.cwd_path().join("settings-update-cwd");
+    fs::create_dir_all(&settings_update_cwd)?;
+    test.codex
+        .submit(Op::UserTurn {
+            environments: None,
+            items: vec![UserInput::Text {
+                text: "second strict governance turn".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            cwd: settings_update_cwd,
+            approval_policy: AskForApproval::OnRequest,
+            approvals_reviewer: None,
+            sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            permission_profile: None,
+            model: test.session_configured.model.clone(),
+            effort: test.config.model_reasoning_effort,
+            summary: None,
+            service_tier: None,
+            collaboration_mode: None,
+            personality: None,
+        })
+        .await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 2, "expected two requests");
+
+    let initial_payload = only_governance_prompt_layer_payload(&requests[0]);
+    assert_complete_strict_prompt_layer_payload(&initial_payload, "initial_context");
+
+    assert!(
+        requests[1].has_message_with_input_texts("developer", |texts| {
+            texts
+                .first()
+                .is_some_and(|text| text.starts_with("<governance_prompt_layers"))
+                && texts
+                    .iter()
+                    .any(|text| text.contains("\"phase\": \"settings_update\""))
+        }),
+        "settings update governance prompt-layer section should lead the developer update"
+    );
+    assert!(
+        requests[1]
+            .message_input_texts("user")
+            .iter()
+            .all(|text| !text.contains("<governance_prompt_layers")),
+        "settings update governance prompt-layer section must stay developer-side"
+    );
+    let settings_payload =
+        governance_prompt_layer_payload_for_phase(&requests[1], "settings_update");
+    assert_complete_strict_prompt_layer_payload(&settings_payload, "settings_update");
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/tests/suite/model_visible_layout.rs
+++ b/codex-rs/core/tests/suite/model_visible_layout.rs
@@ -96,14 +96,19 @@ fn governance_prompt_layer_payload_for_phase(request: &ResponsesRequest, phase: 
 
 fn governance_prompt_layer_payload(section: &str) -> Value {
     let json_start = section
-        .find("\n\n{")
+        .find('{')
+        .expect("governance prompt-layer section should contain a JSON payload");
+    let mut stream = serde_json::Deserializer::from_str(&section[json_start..]).into_iter();
+    let payload = stream
+        .next()
         .expect("governance prompt-layer section should contain a JSON payload")
-        + 2;
-    let json_end = section
-        .rfind("\n</governance_prompt_layers>")
-        .expect("governance prompt-layer section should have a closing tag");
-    serde_json::from_str(&section[json_start..json_end])
-        .expect("governance prompt-layer JSON should parse")
+        .expect("governance prompt-layer JSON should parse");
+    let trailing = section[json_start + stream.byte_offset()..].trim_start();
+    assert!(
+        trailing.starts_with("</governance_prompt_layers>"),
+        "governance prompt-layer section should have a closing tag"
+    );
+    payload
 }
 
 fn assert_complete_strict_prompt_layer_payload(payload: &Value, expected_phase: &str) {

--- a/codex-rs/tools/src/tool_registry_plan_tests.rs
+++ b/codex-rs/tools/src/tool_registry_plan_tests.rs
@@ -523,6 +523,75 @@ fn test_build_specs_agent_job_worker_tools_enabled() {
 }
 
 #[test]
+fn thread_spawn_subagents_keep_observability_tools_but_hide_spawn_tools() {
+    let model_info = model_info();
+    let mut features = Features::with_defaults();
+    features.enable(Feature::Collab);
+    features.enable(Feature::MultiAgentV2);
+    let available_models = Vec::new();
+    let tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &features,
+        image_generation_tool_auth_allowed: true,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+            parent_thread_id: Default::default(),
+            depth: 1,
+            agent_path: None,
+            agent_nickname: None,
+            agent_role: None,
+        }),
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    });
+    let (tools, handlers) = build_specs(
+        &tools_config,
+        /*mcp_tools*/ None,
+        /*deferred_mcp_tools*/ None,
+        &[],
+    );
+
+    assert_contains_tool_names(
+        &tools,
+        &[
+            "inspect_agent_progress",
+            "wait_for_agent_progress",
+            "send_message",
+            "followup_task",
+            "wait_agent",
+            "close_agent",
+            "list_agents",
+        ],
+    );
+    assert_lacks_tool_name(&tools, "spawn_agent");
+    assert_lacks_tool_name(&tools, "spawn_agents_on_csv");
+    assert_lacks_tool_name(&tools, REQUEST_USER_INPUT_TOOL_NAME);
+    assert_lacks_tool_name(&tools, "resume_agent");
+
+    assert!(handlers.contains(&ToolHandlerSpec {
+        name: ToolName::plain("inspect_agent_progress"),
+        kind: ToolHandlerKind::InspectAgentProgress,
+    }));
+    assert!(handlers.contains(&ToolHandlerSpec {
+        name: ToolName::plain("wait_for_agent_progress"),
+        kind: ToolHandlerKind::WaitForAgentProgress,
+    }));
+    assert!(handlers.contains(&ToolHandlerSpec {
+        name: ToolName::plain("send_message"),
+        kind: ToolHandlerKind::SendMessageV2,
+    }));
+    assert!(handlers.contains(&ToolHandlerSpec {
+        name: ToolName::plain("followup_task"),
+        kind: ToolHandlerKind::FollowupTaskV2,
+    }));
+    assert!(!handlers.contains(&ToolHandlerSpec {
+        name: ToolName::plain("spawn_agent"),
+        kind: ToolHandlerKind::SpawnAgentV2,
+    }));
+}
+
+#[test]
 fn memory_consolidation_subagents_do_not_receive_collaboration_tools() {
     let model_info = model_info();
     let mut features = Features::with_defaults();

--- a/docs/fork/README.md
+++ b/docs/fork/README.md
@@ -17,3 +17,4 @@ Current fork-local families documented here include:
 - context maintenance / compaction policy
 - agent observability / E-witness
 - fork update and release-alignment process
+- release-specific post-ingest alignment specs

--- a/docs/fork/release-0.125-alignment-implementation-spec.md
+++ b/docs/fork/release-0.125-alignment-implementation-spec.md
@@ -1,0 +1,478 @@
+# Release 0.125 Post-Ingest Alignment Implementation Spec
+
+This spec defines the fork-owned alignment work to perform after ingesting
+upstream `rust-v0.125.0`.
+
+Primary references:
+
+- [release-alignment-log.md](release-alignment-log.md)
+- [custom-fork-module-inventory.md](custom-fork-module-inventory.md)
+- [fork-update-checklist.md](fork-update-checklist.md)
+
+## Current State
+
+`rust-v0.125.0` has already been ingested into fork `main` using the Path B
+topology from the update checklist:
+
+- ingest branch: `codex/update-0.125-ingest`
+- ingest commit: `43a8773294 merge: ingest upstream rust-v0.125.0`
+- alignment branch: `codex/update-0.125-align`
+- alignment branch delta at spec time: empty
+
+The alignment-only PR guard passed at spec time:
+
+```sh
+git merge-base --is-ancestor codex/update-0.125-ingest main
+git log --oneline main..codex/update-0.125-align
+```
+
+The second command returned no commits. Any PR opened from
+`codex/update-0.125-align` to `main` should therefore contain only fork-owned
+alignment commits, not upstream release commits.
+
+## Purpose
+
+The 0.125 ingest preserved compile-time compatibility and the most important
+fork seams. This alignment pass should now prove the preserved fork behavior is
+still semantically correct on top of upstream 0.125.
+
+The goal is not to re-ingest upstream, rework the merge, or broaden the fork.
+The goal is to add focused tests and small corrections where upstream 0.125
+changed shared runtime paths enough that compile checks are not sufficient.
+
+## In Scope
+
+1. Add targeted integration coverage for strict-v1 prompt layering after PR #45
+   and the 0.125 session/environment refactors.
+2. Add or run targeted coverage for continuation bridge and thread-memory
+   behavior on local and remote compaction paths.
+3. Verify E-witness progress tools still observe live sub-agent progress after
+   upstream rollout-trace and live-thread changes.
+4. Verify thread-spawn sub-agent containment still hides `spawn_agent` while
+   preserving observability tools.
+5. Record any discovered alignment decisions in the release-alignment log.
+
+## Out Of Scope
+
+This alignment pass should not:
+
+- ingest `rust-v0.126.0-alpha.1`
+- refactor the raw 0.125 merge
+- reopen broad compaction-policy architecture
+- move fork-owned crates or modules unless a failing alignment check requires it
+- change app-server refresh/prune API shape unless tests expose a regression
+- change TUI rendering unless a targeted alignment check exposes drift
+
+## Required Invariants
+
+### Review Topology
+
+- `main` remains the canonical fork baseline.
+- `codex/update-0.125-align` starts from the 0.125-ingested `main`.
+- Alignment PRs target `main` only after the guard above still passes.
+- Alignment commits must be fork-owned and reviewable without upstream release
+  commits in the PR diff.
+
+### Runtime Semantics
+
+- Strict-v1 prompt layering remains opt-in and governed by
+  `governance_path_variant`.
+- Initial context and settings-update paths use the same layer ordering:
+  constitutional, role, task, runtime.
+- Continuation bridge and thread memory artifacts remain generated and
+  reinserted according to context-maintenance policy.
+- Required thread-memory generation remains fail-closed in strict paths.
+- E-witness progress events remain observable from parent sessions.
+- Thread-spawned sub-agents keep observability tools but do not receive
+  `spawn_agent`.
+- App-server `thread/refresh/start` and `thread/prune/start` remain present in
+  Rust protocol types and generated JSON/TypeScript schemas.
+
+## Work Packages
+
+### A1: Prompt-Layering Coverage After 0.125 Session Refactors
+
+Problem:
+
+- PR #45 centralized initial-context section assembly.
+- Upstream 0.125 changed session construction, turn environment selection, and
+  settings-update behavior.
+- Existing compile checks do not prove that initial context and update context
+  still preserve strict-v1 prompt-layer insertion and ordering.
+
+Target design:
+
+- Add focused tests around the prompt-visible context generated at thread start.
+- Add focused tests around settings/context updates after a turn configuration
+  change.
+- Prefer existing core test harnesses and response-request inspection helpers.
+
+Required checks:
+
+1. `strict_v1_shadow` emits one `<governance_prompt_layers ...>` block at
+   initial thread start.
+2. The block contains expected constitutional, role, task, and runtime layer
+   categories when corresponding sections exist.
+3. A settings update that changes runtime/developer context still emits or
+   preserves the layering block as intended.
+4. `governance_path_variant = off` does not emit the block.
+
+Likely touched files:
+
+- `codex-rs/core/src/context_manager/updates.rs`
+- `codex-rs/core/src/session/mod.rs`
+- `codex-rs/core/src/session/tests.rs`
+- `codex-rs/core/tests/suite/model_visible_layout.rs` or another existing
+  prompt-shape integration suite
+
+Validation:
+
+```sh
+cd codex-rs
+just fmt
+cargo test -p codex-core governance::prompt_layers --lib
+cargo test -p codex-core model_visible --test all
+```
+
+If the exact integration filter differs, run the concrete test names added in
+this work package.
+
+Status:
+
+- Completed in `codex-rs/core/tests/suite/model_visible_layout.rs`.
+- Added request-level coverage for strict-v1 initial context, strict-v1
+  settings-update context, and governance-off omission.
+- The second-turn request intentionally contains both the original initial
+  prompt-layer block from history and the new `settings_update` block; the test
+  asserts exactly one block for each phase.
+- While compiling the focused integration target, one stale 0.125 test
+  initializer in `codex-rs/core/tests/suite/compact_remote.rs` needed
+  `environments: None` for `Op::UserInput`.
+
+Validation run:
+
+```sh
+cd codex-rs
+just fmt
+cargo test -p codex-core governance --test all
+cargo test -p codex-core governance::prompt_layers --lib
+```
+
+### A2: Continuation Bridge And Thread-Memory Remote Path Verification
+
+Problem:
+
+- The ingest passed local compaction and context-maintenance filters.
+- Upstream 0.125 replaced more rollout persistence with live-thread storage and
+  expanded rollout trace.
+- Remote compaction is the highest-risk path for bridge and thread-memory
+  reinsertion because it crosses model calls, rollout reconstruction, and
+  persisted thread state.
+
+Target design:
+
+- Run existing remote compaction tests first.
+- Add focused tests only if current coverage does not explicitly prove the
+  0.125 seam.
+
+Required checks:
+
+1. Remote compaction still generates continuation bridge requests when
+   configured.
+2. Remote compaction still reinserts `<continuation_bridge ...>` into
+   replacement history.
+3. Strict governed compaction still generates or reuses `<thread_memory ...>`.
+4. Required thread-memory failure still aborts and emits the local error event.
+5. Live-thread rollback/reconstruction still preserves compacted artifact
+   invariants after upstream persistence changes.
+
+Likely touched files:
+
+- `codex-rs/core/src/compact_remote.rs`
+- `codex-rs/core/src/compact.rs`
+- `codex-rs/core/src/governance/thread_memory.rs`
+- `codex-rs/core/src/continuation_bridge.rs`
+- `codex-rs/core/tests/suite/compact_remote.rs`
+- `codex-rs/core/tests/suite/compact.rs`
+
+Validation:
+
+```sh
+cd codex-rs
+just fmt
+cargo test -p codex-core compact_remote --test all
+cargo test -p codex-core compact --test all
+cargo test -p codex-core compact --lib
+```
+
+Status:
+
+- Completed focused remote-path coverage in
+  `codex-rs/core/tests/suite/compact_remote.rs`.
+- Added a thread-memory model-call responder in
+  `codex-rs/core/tests/common/responses.rs`.
+- Added strict remote-hybrid manual compaction coverage proving that:
+  - required thread memory is generated before the compact endpoint call,
+  - the thread-memory request sees the source user and assistant history,
+  - generated `<thread_memory ...>` is reinserted into the follow-up request,
+  - the remote compact summary remains present in replacement history, and
+  - turn-boundary remote compaction does not issue a continuation bridge.
+- Added a fail-closed strict path proving invalid required thread-memory output
+  stops before `/v1/responses/compact`.
+- Test responder request logs are schema-filtered before assertions because the
+  shared `ResponseMock` recorder observes all `/v1/responses` requests evaluated
+  by a mounted mock.
+
+Validation run:
+
+```sh
+cd codex-rs
+just fmt
+cargo test -p codex-core remote_compact_with_strict_governance_reinserts_thread_memory --test all
+cargo test -p codex-core strict_remote_compact_thread_memory_failure_skips_compact_endpoint --test all
+cargo test -p codex-core remote_compact_does_not_issue_bridge_request_when_override_is_configured --test all
+cargo test -p codex-core compaction_policy_matrix --lib
+cargo test -p codex-context-maintenance-policy thread_memory
+```
+
+### A3: E-Witness Progress And Rollout-Trace Coexistence
+
+Problem:
+
+- The ingest preserved `ProgressObservation` and added upstream
+  `rollout_thread_trace.record_protocol_event(...)` into the same event path.
+- Compile checks prove the APIs compose, but not that progress observation still
+  records the right live sub-agent phases.
+
+Target design:
+
+- Add or run integration tests that exercise a spawned child session and inspect
+  progress through the fork-owned E-witness tools.
+- Confirm compatibility-only events do not incorrectly advance observed
+  progress.
+
+Required checks:
+
+1. `inspect_agent_progress` returns a coherent snapshot after child spawn.
+2. `wait_for_agent_progress` can observe a material phase transition.
+3. Child completion still records observable progress for the parent.
+4. Rollout-trace protocol recording does not duplicate or suppress E-witness
+   progress events.
+
+Likely touched files:
+
+- `codex-rs/core/src/agent/control.rs`
+- `codex-rs/core/src/session/mod.rs`
+- `codex-rs/core/src/tools/handlers/agent_progress.rs`
+- `codex-rs/core/tests/suite/subagent_notifications.rs`
+- `codex-rs/tools/src/agent_progress_tool.rs`
+
+Validation:
+
+```sh
+cd codex-rs
+just fmt
+cargo test -p codex-tools agent_progress_tool
+cargo test -p codex-core tools::handlers::agent_progress --lib
+cargo test -p codex-core subagent_notifications --test all
+```
+
+Status:
+
+- Completed focused coexistence coverage in
+  `codex-rs/core/src/tools/handlers/multi_agents_tests.rs`.
+- Added a test that enables a real rollout trace bundle, sends a
+  `ProgressObservation::CompatibilityOnly` protocol event through
+  `send_event_raw`, and proves:
+  - the compatibility-only event is recorded as a rollout trace protocol event,
+  - the E-witness progress sequence does not advance, and
+  - the progress snapshot remains at `seq = 0`.
+- Re-ran the existing live progress handler checks for inspect/wait behavior,
+  raw observed events, legacy echo deduplication, and public progress tool
+  schemas.
+
+Validation run:
+
+```sh
+cd codex-rs
+just fmt
+cargo test -p codex-core compatibility_only_protocol_events_are_traced_without_progress_observation --lib
+cargo test -p codex-core inspect_agent_progress_reports_reasoning_phase_for_live_subagent --lib
+cargo test -p codex-core wait_for_agent_progress --lib
+cargo test -p codex-core session_send_event_observes_primary_item_started_once_with_legacy_echoes --lib
+cargo test -p codex-core observed_raw --lib
+cargo test -p codex-tools agent_progress_tool
+```
+
+### A4: Thread-Spawn Tool Containment Recheck
+
+Problem:
+
+- Upstream 0.125 changed tool/runtime routing around MCP, shell, unified exec,
+  and plugin movement.
+- The fork invariant is subtle: thread-spawned sub-agents should retain
+  observability tools while not receiving `spawn_agent`.
+
+Target design:
+
+- Add a focused test at the tool-plan layer if existing tests do not assert the
+  exact 0.125 behavior.
+- Prefer `codex-tools` tests for the policy shape and `codex-core` tests only
+  if runtime source mapping is suspect.
+
+Required checks:
+
+1. Root/default sessions expose `spawn_agent` when collaboration tools are
+   enabled.
+2. Thread-spawned sub-agents do not expose `spawn_agent`.
+3. Thread-spawned sub-agents do expose `inspect_agent_progress` and
+   `wait_for_agent_progress`.
+4. Memory-consolidation sub-agents still receive the stricter hidden tool
+   surface intended for that source.
+
+Likely touched files:
+
+- `codex-rs/tools/src/tool_config.rs`
+- `codex-rs/tools/src/tool_registry_plan_tests.rs`
+- `codex-rs/core/src/tools/spec.rs`
+- `codex-rs/core/src/tools/spec_tests.rs`
+
+Validation:
+
+```sh
+cd codex-rs
+just fmt
+cargo test -p codex-tools thread_spawn_subagents_keep_observability_but_hide_spawn
+cargo test -p codex-core tools::spec::tests --lib
+```
+
+Status:
+
+- Completed final tool-registry coverage in
+  `codex-rs/tools/src/tool_registry_plan_tests.rs`.
+- Added a thread-spawn subagent registry-plan test proving that the final
+  model-visible tool list and handler registry:
+  - keep `inspect_agent_progress` and `wait_for_agent_progress`,
+  - keep non-spawning coordination tools (`send_message`, `followup_task`,
+    `wait_agent`, `close_agent`, `list_agents`),
+  - omit `spawn_agent`, `spawn_agents_on_csv`, `resume_agent`, and
+    `request_user_input`, and
+  - do not register a `spawn_agent` handler for thread-spawn subagents.
+- Re-ran adjacent tool-surface tests for memory-consolidation subagents and
+  agent-job subagents so the three subagent classes stay distinguished.
+
+Validation run:
+
+```sh
+cd codex-rs
+just fmt
+cargo test -p codex-tools thread_spawn_subagents --lib
+cargo test -p codex-tools memory_consolidation_subagents_do_not_receive_collaboration_tools --lib
+cargo test -p codex-tools test_build_specs_agent_job_worker_tools_enabled --lib
+cargo test -p codex-tools subagents_keep_request_user_input_mode_config_and_agent_jobs_workers_opt_in_by_label --lib
+```
+
+### A5: Alignment Log And Watchlist Closure
+
+Problem:
+
+- The raw ingest log records conflict decisions and validation.
+- The post-ingest alignment branch should record any semantic findings,
+  especially if a work package discovers that no code change is needed.
+
+Target design:
+
+- Add a short post-ingest alignment note to `release-alignment-log.md` once
+  work packages are complete.
+- Update `custom-fork-module-inventory.md` only if this pass changes the fork
+  surface area or adds a new hot file.
+
+Required checks:
+
+1. Record which work packages were implemented or verified as no-op.
+2. Record validation commands and any intentionally deferred checks.
+3. Re-run the alignment-only PR guard before opening the PR.
+
+Likely touched files:
+
+- `docs/fork/release-alignment-log.md`
+- `docs/fork/custom-fork-module-inventory.md` only if the inventory changes
+
+Validation:
+
+```sh
+git merge-base --is-ancestor codex/update-0.125-ingest main
+git log --oneline main..codex/update-0.125-align
+```
+
+The second command must list only fork-owned alignment commits.
+
+Status:
+
+- Completed the post-ingest closure note in
+  `docs/fork/release-alignment-log.md`.
+- Left `docs/fork/custom-fork-module-inventory.md` unchanged because A1-A4 add
+  focused verification for existing fork-owned runtime bundles and do not add,
+  remove, or replace a bundle.
+- Re-ran the alignment-only PR guard on 2026-04-25. At that point
+  `codex/update-0.125-ingest` was an ancestor of `main`, and
+  `git log --oneline main..codex/update-0.125-align` produced no output because
+  the A1-A5 work was still uncommitted.
+
+## Recommended PR Sequence
+
+Keep the first PR small and verification-heavy:
+
+1. `125-A1`: prompt-layering tests and any minimal fix required by those tests.
+2. `125-A2`: remote compaction/thread-memory verification and any minimal fix.
+3. `125-A3/A4`: E-witness progress plus thread-spawn containment checks.
+4. `125-A5`: final release-log closure if not already included.
+
+If A1 produces only tests and no runtime changes, it can include A5 log updates
+for the prompt-layering result. Avoid combining remote compaction fixes with
+tool-surface fixes unless both are purely test-only.
+
+## Validation Plan
+
+Minimum validation before opening the first alignment PR:
+
+```sh
+cd codex-rs
+just fmt
+cargo test -p codex-core governance::prompt_layers --lib
+cargo test -p codex-core context_maintenance --lib
+cargo test -p codex-core tools::spec::tests --lib
+cargo test -p codex-tools
+```
+
+Additional validation before merging all 0.125 alignment work:
+
+```sh
+cd codex-rs
+cargo test -p codex-core compact_remote --test all
+cargo test -p codex-core compact --test all
+cargo test -p codex-core subagent_notifications --test all
+cargo test -p codex-app-server suite::v2::compaction::thread_refresh_start_triggers_compaction_and_returns_empty_response --test all -- --exact
+cargo test -p codex-app-server suite::v2::compaction::thread_prune_start_triggers_compaction_and_returns_empty_response --test all -- --exact
+```
+
+If any work package touches config schema or app-server protocol types, also
+run:
+
+```sh
+cd codex-rs
+just write-config-schema
+just write-app-server-schema
+cargo test -p codex-app-server-protocol --test schema_fixtures
+```
+
+## Deferred Follow-Ups
+
+These are intentionally not part of the first 0.125 alignment PR unless a test
+failure makes them necessary:
+
+- broader TUI snapshot refresh
+- full workspace `cargo test`
+- alpha-release (`0.126.0-alpha.1`) ingest preparation
+- policy-crate architecture changes from older compaction follow-up specs
+- broad cleanup of legacy release-rebase scripts

--- a/docs/fork/release-alignment-log.md
+++ b/docs/fork/release-alignment-log.md
@@ -174,6 +174,56 @@ and exec/runtime hardening. The highest-risk fork seams are:
   - `git merge-base --is-ancestor codex/update-0.125-ingest main`
   - `git log --oneline main..codex/update-0.125-align`
 
+### Post-ingest alignment note
+
+The `codex/update-0.125-align` pass added focused verification for the
+fork-owned seams identified above rather than changing runtime behavior.
+
+- A1 added request-level coverage proving strict governance prompt layers are
+  visible in initial and settings-update request payloads, and omitted when
+  governance is disabled.
+- A2 added remote-compaction coverage proving strict governance reinserts fresh
+  thread memory before calling `/responses/compact`, and fails closed without
+  calling compact when thread-memory refresh fails.
+- A3 added trace/observability coverage proving compatibility-only raw protocol
+  events are still recorded in rollout traces without advancing the live
+  progress reducer.
+- A4 added final tool-registry coverage proving thread-spawn sub-agents keep
+  observability and coordination tools while omitting spawn/resume/user-input
+  tools.
+- `custom-fork-module-inventory.md` was left unchanged because this pass did
+  not add, remove, or replace a fork-owned runtime bundle.
+
+Validation added by the post-ingest alignment pass:
+
+- `just fmt`
+- `cargo test -p codex-core governance --test all`
+- `cargo test -p codex-core governance::prompt_layers --lib`
+- `cargo test -p codex-core remote_compact_with_strict_governance_reinserts_thread_memory --test all`
+- `cargo test -p codex-core strict_remote_compact_thread_memory_failure_skips_compact_endpoint --test all`
+- `cargo test -p codex-core remote_compact_does_not_issue_bridge_request_when_override_is_configured --test all`
+- `cargo test -p codex-core compaction_policy_matrix --lib`
+- `cargo test -p codex-context-maintenance-policy thread_memory`
+- `cargo test -p codex-core compatibility_only_protocol_events_are_traced_without_progress_observation --lib`
+- `cargo test -p codex-core inspect_agent_progress_reports_reasoning_phase_for_live_subagent --lib`
+- `cargo test -p codex-core wait_for_agent_progress --lib`
+- `cargo test -p codex-core session_send_event_observes_primary_item_started_once_with_legacy_echoes --lib`
+- `cargo test -p codex-core observed_raw --lib`
+- `cargo test -p codex-tools agent_progress_tool`
+- `cargo test -p codex-tools thread_spawn_subagents --lib`
+- `cargo test -p codex-tools memory_consolidation_subagents_do_not_receive_collaboration_tools --lib`
+- `cargo test -p codex-tools test_build_specs_agent_job_worker_tools_enabled --lib`
+- `cargo test -p codex-tools subagents_keep_request_user_input_mode_config_and_agent_jobs_workers_opt_in_by_label --lib`
+- `git diff --check`
+
+Alignment-only PR guard re-run on 2026-04-25:
+
+- `git merge-base --is-ancestor codex/update-0.125-ingest main`
+- `git log --oneline main..codex/update-0.125-align`
+
+At guard time the second command listed no inherited upstream commits and no
+alignment commits yet; the branch-local work remained uncommitted.
+
 ## 0.123.0 -> 0.124.0 (prep + ingest snapshot)
 
 ### Refs


### PR DESCRIPTION
## Summary

This PR adds the fork-owned post-ingest alignment work for upstream `rust-v0.125.0` after the raw ingest was landed on `main`.

It adds focused verification for:

- strict governance prompt-layer visibility in request payloads
- strict remote compaction thread-memory reinsertion and fail-closed behavior
- compatibility-only raw protocol event rollout tracing without live progress advancement
- thread-spawn subagent tool containment in the final tool registry

It also records the 0.125 alignment implementation spec and closes the release log with the A1-A5 validation notes.

## PR Guard

The alignment-only guard was re-run after committing:

```sh
git merge-base --is-ancestor codex/update-0.125-ingest main
git log --oneline main..HEAD
```

`main..HEAD` contains only:

```sh
c93014ef34 test: cover 0.125 fork alignment seams
```

So this PR should not include inherited upstream 0.125 release commits.

## Validation

```sh
cd codex-rs
just fmt
cargo test -p codex-core governance --test all
cargo test -p codex-core governance::prompt_layers --lib
cargo test -p codex-core remote_compact_with_strict_governance_reinserts_thread_memory --test all
cargo test -p codex-core strict_remote_compact_thread_memory_failure_skips_compact_endpoint --test all
cargo test -p codex-core remote_compact_does_not_issue_bridge_request_when_override_is_configured --test all
cargo test -p codex-core compaction_policy_matrix --lib
cargo test -p codex-context-maintenance-policy thread_memory
cargo test -p codex-core compatibility_only_protocol_events_are_traced_without_progress_observation --lib
cargo test -p codex-core inspect_agent_progress_reports_reasoning_phase_for_live_subagent --lib
cargo test -p codex-core wait_for_agent_progress --lib
cargo test -p codex-core session_send_event_observes_primary_item_started_once_with_legacy_echoes --lib
cargo test -p codex-core observed_raw --lib
cargo test -p codex-tools agent_progress_tool
cargo test -p codex-tools thread_spawn_subagents --lib
cargo test -p codex-tools memory_consolidation_subagents_do_not_receive_collaboration_tools --lib
cargo test -p codex-tools test_build_specs_agent_job_worker_tools_enabled --lib
cargo test -p codex-tools subagents_keep_request_user_input_mode_config_and_agent_jobs_workers_opt_in_by_label --lib
git diff --check
git diff --check main..HEAD
```